### PR TITLE
Roller shutter bugs fix

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -22,6 +22,8 @@ NOSSL=0
 SPI_MODE="DIO"
 BOARD_SELECTED=0
 
+set -e
+
 export PATH=/hdd2/Espressif/sdk_3x/xtensa-lx106-elf/bin:$PATH
 export COMPILE=gcc
 
@@ -195,7 +197,7 @@ CFG_SECTOR=0x3C
 case $FLASH_SIZE in
    "512")
     "512 flash size is not supported"
-    exit 0
+    exit 1
    ;;
    "2048")
      SPI_SIZE_MAP=3
@@ -226,7 +228,12 @@ else
   EXTRA_CCFLAGS="${EXTRA_CCFLAGS} -DNOSSL=0"
 fi
 
+if [ "debug" = "$2" ]; then
+  EXTRA_CCFLAGS="${EXTRA_CCFLAGS} -DSUPLA_DEBUG"
+fi
+
 [ -e $OUTDIR ] || mkdir $OUTDIR
+
 
 if [ "$FOTA" -eq 1 ]; then
 
@@ -252,17 +259,16 @@ if [ "$FOTA" -eq 1 ]; then
 
    make SUPLA_DEP_LIBS="$DEP_LIBS" FOTA="$FOTA" BOARD=$1 CFG_SECTOR="$CFG_SECTOR" BOOT=new APP="$APP" SPI_SPEED=40 SPI_MODE="$SPI_MODE" SPI_SIZE_MAP="$SPI_SIZE_MAP" __EXTRA_CCFLAGS="$EXTRA_CCFLAGS" && \
    cp $BIN_PATH/upgrade/user"$APP"."$FLASH_SIZE".new."$SPI_SIZE_MAP".bin "$OUTDIR"/"$BOARD_NAME"_user"$APP"."$FLASH_SIZE"_"$SPI_MODE".new."${SPI_SIZE_MAP}${OUTPUT_FILENAME_SUFFIX}".sdk3x.bin && \
-   cp $SDK_PATH/bin/boot_v1.6.bin $OUTDIR/boot_v1.6.bin
+   cp $SDK_PATH/bin/boot_v1.6.bin $OUTDIR/boot_v1.6.bin || exit $?
 
    exit 0
-
 else
 
    cp ./ld/"$LD_DIR"/"$FLASH_SIZE"_eagle.app.v6.ld $SDK_PATH/ld/eagle.app.v6.ld || exit 1
 
    make SUPLA_DEP_LIBS="$DEP_LIBS" BOARD=$1 CFG_SECTOR=$CFG_SECTOR BOOT=new APP=0 SPI_SPEED=40 SPI_MODE="$SPI_MODE" SPI_SIZE_MAP="$SPI_SIZE_MAP" __EXTRA_CCFLAGS="$EXTRA_CCFLAGS" && \
    cp $BIN_PATH/eagle.flash.bin $OUTDIR/"$BOARD_NAME"_"$FLASH_SIZE"_"$SPI_MODE"_eagle.flash.sdk3x.bin && \
-   cp $BIN_PATH/eagle.irom0text.bin $OUTDIR/"$BOARD_NAME"_"$FLASH_SIZE"_"$SPI_MODE"_eagle.irom0text.sdk3x.bin &&
+   cp $BIN_PATH/eagle.irom0text.bin $OUTDIR/"$BOARD_NAME"_"$FLASH_SIZE"_"$SPI_MODE"_eagle.irom0text.sdk3x.bin || exit $?
    
    exit 0
 fi

--- a/src/include/board/inCan.c
+++ b/src/include/board/inCan.c
@@ -212,7 +212,7 @@ void ICACHE_FLASH_ATTR supla_esp_board_set_channels(
     channels[2].Type = SUPLA_CHANNELTYPE_RELAY;
     channels[2].FuncList = SUPLA_BIT_FUNC_CONTROLLINGTHEROLLERSHUTTER;
     channels[2].Default = SUPLA_CHANNELFNC_CONTROLLINGTHEROLLERSHUTTER;
-    channels[2].value[0] = (*supla_rs_cfg[0].position) - 1;
+    channels[2].value[0] = ((*supla_rs_cfg[0].position) - 100 + 50) / 100;
 
 #endif
 }

--- a/src/include/board/inCan.c
+++ b/src/include/board/inCan.c
@@ -212,7 +212,7 @@ void ICACHE_FLASH_ATTR supla_esp_board_set_channels(
     channels[2].Type = SUPLA_CHANNELTYPE_RELAY;
     channels[2].FuncList = SUPLA_BIT_FUNC_CONTROLLINGTHEROLLERSHUTTER;
     channels[2].Default = SUPLA_CHANNELFNC_CONTROLLINGTHEROLLERSHUTTER;
-    channels[2].value[0] = ((*supla_rs_cfg[0].position) - 100 + 50) / 100;
+    channels[2].value[0] = supla_esp_gpio_rs_get_current_position(&supla_rs_cfg[0]);
 
 #endif
 }

--- a/src/include/board/rs_module.c
+++ b/src/include/board/rs_module.c
@@ -114,7 +114,7 @@ void ICACHE_FLASH_ATTR supla_esp_board_set_channels(
   channels[0].Type = SUPLA_CHANNELTYPE_RELAY;
   channels[0].FuncList = SUPLA_BIT_FUNC_CONTROLLINGTHEROLLERSHUTTER;
   channels[0].Default = SUPLA_CHANNELFNC_CONTROLLINGTHEROLLERSHUTTER;
-  channels[0].value[0] = ((*supla_rs_cfg[0].position) - 100 + 50)/100;
+  channels[0].value[0] = supla_esp_gpio_rs_get_current_position(&supla_rs_cfg[0]);
 
   channels[1].Number = 1;
   channels[1].Type = SUPLA_CHANNELTYPE_SENSORNO;

--- a/src/include/board/rs_module.c
+++ b/src/include/board/rs_module.c
@@ -114,7 +114,7 @@ void ICACHE_FLASH_ATTR supla_esp_board_set_channels(
   channels[0].Type = SUPLA_CHANNELTYPE_RELAY;
   channels[0].FuncList = SUPLA_BIT_FUNC_CONTROLLINGTHEROLLERSHUTTER;
   channels[0].Default = SUPLA_CHANNELFNC_CONTROLLINGTHEROLLERSHUTTER;
-  channels[0].value[0] = (*supla_rs_cfg[0].position) - 1;
+  channels[0].value[0] = ((*supla_rs_cfg[0].position) - 100 + 50)/100;
 
   channels[1].Number = 1;
   channels[1].Type = SUPLA_CHANNELTYPE_SENSORNO;

--- a/src/user/supla_esp_devconn.c
+++ b/src/user/supla_esp_devconn.c
@@ -334,7 +334,7 @@ supla_esp_devconn_send_channel_values_cb(void *ptr) {
 				   && supla_rs_cfg[a].down != NULL
 				   && supla_rs_cfg[a].up->channel != 255 ) {
 
-				supla_esp_channel_value_changed(supla_rs_cfg[a].up->channel, ((*supla_rs_cfg[a].position)-100)/100);
+				supla_esp_channel_value_changed(supla_rs_cfg[a].up->channel, ((*supla_rs_cfg[a].position)-100+50)/100);
 
 			}
 		}

--- a/src/user/supla_esp_devconn.c
+++ b/src/user/supla_esp_devconn.c
@@ -327,6 +327,7 @@ supla_esp_devconn_send_channel_values_cb(void *ptr) {
 
 	if ( supla_esp_devconn_is_registered() == 1 ) {
 
+#ifdef _ROLLERSHUTTER_SUPPORT
 		int a;
 
 		for(a=0; a<RS_MAX_COUNT; a++) {
@@ -337,6 +338,7 @@ supla_esp_devconn_send_channel_values_cb(void *ptr) {
 				supla_esp_channel_value_changed(supla_rs_cfg[a].up->channel, supla_esp_gpio_rs_get_current_position(&supla_rs_cfg[a]));
 			}
 		}
+#endif /*_ROLLERSHUTTER_SUPPORT*/
 
 		supla_esp_board_send_channel_values_with_delay(devconn->srpc);
 

--- a/src/user/supla_esp_devconn.c
+++ b/src/user/supla_esp_devconn.c
@@ -334,8 +334,7 @@ supla_esp_devconn_send_channel_values_cb(void *ptr) {
 				   && supla_rs_cfg[a].down != NULL
 				   && supla_rs_cfg[a].up->channel != 255 ) {
 
-				supla_esp_channel_value_changed(supla_rs_cfg[a].up->channel, ((*supla_rs_cfg[a].position)-100+50)/100);
-
+				supla_esp_channel_value_changed(supla_rs_cfg[a].up->channel, supla_esp_gpio_rs_get_current_position(&supla_rs_cfg[a]));
 			}
 		}
 

--- a/src/user/supla_esp_gpio.c
+++ b/src/user/supla_esp_gpio.c
@@ -277,24 +277,24 @@ supla_esp_gpio_rs_task_processing(supla_roller_shutter_cfg_t *rs_cfg) {
 		return;
 	}
 
-	uint8 percent = ((*rs_cfg->position)-100)/100;
+	int position = ((*rs_cfg->position)-100);
 
 
 	if ( rs_cfg->task.direction == RS_DIRECTION_NONE ) {
 
-		if ( percent > rs_cfg->task.percent ) {
+		if ( position > rs_cfg->task.percent * 100 ) {
 
 			rs_cfg->task.direction = RS_DIRECTION_UP;
 			supla_esp_gpio_rs_set_relay(rs_cfg, RS_RELAY_UP, 0, 0);
 
-		    //supla_log(LOG_DEBUG, "task go UP %i,%i", percent, rs_cfg->task.percent);
+		    //supla_log(LOG_DEBUG, "task go UP %i,%i", position, rs_cfg->task.percent);
 
-		} else if ( percent < rs_cfg->task.percent ) {
+		} else if ( position < rs_cfg->task.percent * 100 ) {
 
 			rs_cfg->task.direction = RS_DIRECTION_DOWN;
 			supla_esp_gpio_rs_set_relay(rs_cfg, RS_RELAY_DOWN, 0, 0);
 
-			//supla_log(LOG_DEBUG, "task go DOWN, %i,%i", percent, rs_cfg->task.percent);
+			//supla_log(LOG_DEBUG, "task go DOWN, %i,%i", position, rs_cfg->task.percent);
 
 		} else {
 			//supla_log(LOG_DEBUG, "task finished #1");
@@ -304,9 +304,9 @@ supla_esp_gpio_rs_task_processing(supla_roller_shutter_cfg_t *rs_cfg) {
 		}
 
 	} else if ( ( rs_cfg->task.direction == RS_DIRECTION_UP
-				  && percent <= rs_cfg->task.percent )
+				  && position <= rs_cfg->task.percent * 100 )
 				|| ( rs_cfg->task.direction == RS_DIRECTION_DOWN
-					 && percent >= rs_cfg->task.percent )  ) {
+					 && position >= rs_cfg->task.percent * 100)  ) {
 
 		if ( rs_cfg->task.percent == 0
 			 && 1 == supla_esp_gpio_rs_time_margin(rs_cfg, rs_cfg->full_opening_time, rs_cfg->up_time, 5) ) { // margin 5%
@@ -377,7 +377,9 @@ supla_esp_gpio_rs_timer_cb(void *timer_arg) {
 		if ( rs_cfg->last_position != *rs_cfg->position ) {
 
 			rs_cfg->last_position = *rs_cfg->position;
-			char pos = (rs_cfg->last_position-100)/100;
+      // we add 50 here in order to round position to closest integer
+      // instead of rounding down, which could translate 1.99% to 1%
+			char pos = (rs_cfg->last_position-100+50)/100;
 			supla_esp_channel_value_changed(rs_cfg->up->channel, pos);
 
 #ifdef BOARD_ON_ROLLERSHUTTER_POSITION_CHANGED

--- a/src/user/supla_esp_gpio.c
+++ b/src/user/supla_esp_gpio.c
@@ -372,7 +372,7 @@ supla_esp_gpio_rs_timer_cb(void *timer_arg) {
 
 	supla_esp_gpio_rs_task_processing(rs_cfg);
 
-	if ( rs_cfg->last_time-rs_cfg->last_comm_time >= 1000 ) { // 1000 == 1 sec.
+	if ( rs_cfg->last_time-rs_cfg->last_comm_time >= 500000 ) { // 500 ms.
 
 		if ( rs_cfg->last_position != *rs_cfg->position ) {
 
@@ -421,7 +421,7 @@ void GPIO_ICACHE_FLASH supla_esp_gpio_rs_add_task(int idx, uint8 percent) {
 
 	if ( idx < 0
 		 || idx >= RS_MAX_COUNT
-		 || ((*supla_rs_cfg[idx].position)-100)/100 == percent )
+		 || ((*supla_rs_cfg[idx].position)-100+50)/100 == percent )
 		return;
 
 	if ( percent > 100 )

--- a/src/user/supla_esp_gpio.h
+++ b/src/user/supla_esp_gpio.h
@@ -147,6 +147,7 @@ supla_esp_gpio_rs_cancel_task(supla_roller_shutter_cfg_t *rs_cfg);
 void GPIO_ICACHE_FLASH supla_esp_gpio_rs_add_task(int idx, uint8 percent);
 
 supla_roller_shutter_cfg_t *supla_esp_gpio_get_rs__cfg(int port);
+sint8 supla_esp_gpio_rs_get_current_position(supla_roller_shutter_cfg_t *rs_cfg);
 #endif /*_ROLLERSHUTTER_SUPPORT*/
 
 #endif /* SUPLA_ESP_GPIO_H_ */

--- a/src/user/supla_esp_gpio.h
+++ b/src/user/supla_esp_gpio.h
@@ -57,9 +57,6 @@ typedef struct {
 	uint8 flags;
 	uint8 channel;
 	unsigned _supla_int_t channel_flags;
-
-	unsigned int last_time;
-
 }supla_relay_cfg_t;
 
 typedef struct {

--- a/test/check_compilation_of_all_targets.sh
+++ b/test/check_compilation_of_all_targets.sh
@@ -42,6 +42,8 @@ lightswitch_x2_DHT22
 lightswitch_x2_54_DHT22
 "
 
+failed_targets=""
+
 cd /CProjects/supla-espressif-esp/src
 
 for i in ${targets}
@@ -51,7 +53,25 @@ do
   echo "======================================================"
   echo
   ./build.sh $i
+  if [ "$?" -ne "0" ]
+  then
+    echo "Building target $i failed"
+    failed_targets="$failed_targets $i"
+  fi
+
+  echo "======================================================"
+
 done
+
+if [ "${#failed_targets}" -ne "0" ]
+then
+  echo "======================================================"
+  echo "Failed targets:"
+  echo "======================================================"
+  echo $failed_targets
+  echo "======================================================"
+  exit 1
+fi
 
 echo "All targets compiled successfully!"
 

--- a/test/common_cmake_definitions.txt
+++ b/test/common_cmake_definitions.txt
@@ -7,11 +7,13 @@ set(CMAKE_BUILD_TYPE Debug)
 include_directories(..)
 include_directories(../..)
 include_directories(doubles/)
+include_directories(../../tests/doubles/)
 include_directories(../../../../../../test/doubles/)
 include_directories(../../../../../../supla-common/)
 include_directories(../../../../../../)
 include_directories(../../../../../../src/include/)
 include_directories(../../../../../../src/user/)
+include_directories(../../../../../../src/nettle/include)
 
 mark_as_advanced(
 BUILD_GMOCK
@@ -40,6 +42,8 @@ file(GLOB TEST_SRC
 file(GLOB COMMON_DOUBLE_SRC 
   ../../../../../../test/doubles/*.cpp
   ../../../../../../test/doubles/*.c
+  ../../tests/doubles/*.cpp
+  ../../tests/doubles/*.c
   )
 file(GLOB DOUBLE_SRC doubles/*.cpp doubles/*.c)
 

--- a/test/src/roller_shutter_tests.cpp
+++ b/test/src/roller_shutter_tests.cpp
@@ -1320,7 +1320,7 @@ TEST_F(RollerShutterTestsF, MoveDownWithSmallSteps) {
   EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
   EXPECT_TRUE(eagleStub.getGpioValue(DOWN_GPIO));
 
-  // +10 ms 
+  // +50 ms 
   for (int i = 0; i < 5; i++) {
     curTime += 10000; // +10ms
     rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
@@ -1391,3 +1391,47 @@ TEST_F(RollerShutterTestsF, TwoRelaysOnProblem) {
 
 }
 
+TEST(RollerShutterTests, GetRelayPos) {
+  int position = 0;
+  supla_roller_shutter_cfg_t *rs = &supla_rs_cfg[0];
+  rs->position = &position;
+  EXPECT_EQ(supla_esp_gpio_rs_get_current_position(nullptr), -1);
+  EXPECT_EQ(supla_esp_gpio_rs_get_current_position(rs), -1);
+
+  position = 99;
+  EXPECT_EQ(supla_esp_gpio_rs_get_current_position(rs), -1);
+
+  position = 100;
+  EXPECT_EQ(supla_esp_gpio_rs_get_current_position(rs), 0);
+
+  position = 200;
+  EXPECT_EQ(supla_esp_gpio_rs_get_current_position(rs), 1);
+
+  position = 5100;
+  EXPECT_EQ(supla_esp_gpio_rs_get_current_position(rs), 50);
+
+  position = 10100;
+  EXPECT_EQ(supla_esp_gpio_rs_get_current_position(rs), 100);
+
+  position = 150;
+  EXPECT_EQ(supla_esp_gpio_rs_get_current_position(rs), 1);
+
+  position = 149;
+  EXPECT_EQ(supla_esp_gpio_rs_get_current_position(rs), 0);
+
+  position = 151;
+  EXPECT_EQ(supla_esp_gpio_rs_get_current_position(rs), 1);
+
+  position = 249;
+  EXPECT_EQ(supla_esp_gpio_rs_get_current_position(rs), 1);
+
+  position = 250;
+  EXPECT_EQ(supla_esp_gpio_rs_get_current_position(rs), 2);
+
+  position = 10100;
+  EXPECT_EQ(supla_esp_gpio_rs_get_current_position(rs), 100);
+
+  position = 10101;
+  EXPECT_EQ(supla_esp_gpio_rs_get_current_position(rs), -1);
+
+}

--- a/test/src/roller_shutter_tests.cpp
+++ b/test/src/roller_shutter_tests.cpp
@@ -1169,3 +1169,196 @@ TEST_F(RollerShutterTestsF, MoveDownWithUnfortunateTiming2) {
   EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
 
 }
+
+/*
+TEST_F(RollerShutterTestsF, MoveDownWithSmallSteps) {
+  uint32_t curTime = 100;
+  EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
+
+  supla_esp_gpio_init();
+
+  supla_roller_shutter_cfg_t *rsCfg = supla_esp_gpio_get_rs__cfg(1);
+  ASSERT_NE(rsCfg, nullptr);
+
+  os_timer_func_t *rsTimerCb = lastTimerCb;
+
+  *rsCfg->full_opening_time = 25000; // 20 s
+  *rsCfg->full_closing_time = 25000; 
+  *rsCfg->position = 100; // actual position: (x - 100)/100 = 0%
+
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, 100);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // +2000 ms 
+  for (int i = 0; i < 200; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  // nothing should change
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, 100);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // Move RS down. 
+  EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
+  supla_esp_gpio_rs_add_task(0, 1);
+  EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
+
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, 100);
+  // add task doesn't change relay state. At least one callback has to be called
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  rsTimerCb(rsCfg);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_TRUE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // +240 ms 
+  for (int i = 0; i < 24; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+  EXPECT_LT(*rsCfg->position, (100+(1*100)));
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_TRUE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // +10 ms 
+  for (int i = 0; i < 1; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, (100+(1*100)));
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // +2000 ms 
+  for (int i = 0; i < 200; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  supla_esp_gpio_rs_add_task(0, 2);
+  EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
+ 
+  // +240 ms 
+  for (int i = 0; i < 24; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+  EXPECT_LT(*rsCfg->position, (100+ (2*100)));
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_TRUE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // +10 ms 
+  for (int i = 0; i < 2; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, (100+(2*100)));
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+
+  // +2000 ms 
+  for (int i = 0; i < 200; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  supla_esp_gpio_rs_add_task(0, 1);
+  EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
+ 
+  // +240 ms 
+  for (int i = 0; i < 24; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+  EXPECT_GT(*rsCfg->position, (100+ (1*100)));
+  EXPECT_TRUE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // +10 ms 
+  for (int i = 0; i < 200; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, (100+(1*100)));
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+}
+*/
+
+TEST_F(RollerShutterTestsF, TwoRelaysOnProblem) {
+  uint32_t curTime = 100;
+  EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
+
+  supla_esp_gpio_init();
+
+  supla_roller_shutter_cfg_t *rsCfg = supla_esp_gpio_get_rs__cfg(1);
+  ASSERT_NE(rsCfg, nullptr);
+
+  os_timer_func_t *rsTimerCb = lastTimerCb;
+
+  *rsCfg->full_opening_time = 25000; // 20 s
+  *rsCfg->full_closing_time = 25000; 
+  *rsCfg->position = 100 + (50*100); // actual position: (x - 100)/100 = 50%
+
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // +2000 ms 
+  for (int i = 0; i < 200; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  // nothing should change
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, 100 + (50*100));
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // Trigger both down and up actions
+  supla_esp_gpio_rs_set_relay(rsCfg, RS_RELAY_DOWN, 0, 0);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_TRUE(eagleStub.getGpioValue(DOWN_GPIO));
+  EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
+
+  supla_esp_gpio_rs_set_relay(rsCfg, RS_RELAY_UP, 0, 0);
+  // singe UP request just switched off DOWN relay, this action should be 
+  // scheduled as delayed trigger, so both relays should be off now
+  EXPECT_EQ(rsCfg->delayed_trigger.value, RS_RELAY_UP);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // simulate delayed trigger execution
+  curTime += 1000000;
+  rsTimerCb(rsCfg);
+  supla_esp_gpio_rs_set_relay(rsCfg, rsCfg->delayed_trigger.value, 0, 0);
+  EXPECT_TRUE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+  EXPECT_EQ(rsCfg->delayed_trigger.value, RS_RELAY_UP); // TODO: fix
+
+}
+

--- a/test/src/roller_shutter_tests.cpp
+++ b/test/src/roller_shutter_tests.cpp
@@ -1170,7 +1170,6 @@ TEST_F(RollerShutterTestsF, MoveDownWithUnfortunateTiming2) {
 
 }
 
-/*
 TEST_F(RollerShutterTestsF, MoveDownWithSmallSteps) {
   uint32_t curTime = 100;
   EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
@@ -1283,8 +1282,8 @@ TEST_F(RollerShutterTestsF, MoveDownWithSmallSteps) {
   EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
  
   // +240 ms 
-  for (int i = 0; i < 24; i++) {
-    curTime += 10000; // +10ms
+  for (int i = 0; i < 20; i++) {
+    curTime += 12000; // +10ms
     rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
   }
   EXPECT_GT(*rsCfg->position, (100+ (1*100)));
@@ -1293,7 +1292,7 @@ TEST_F(RollerShutterTestsF, MoveDownWithSmallSteps) {
 
   // +10 ms 
   for (int i = 0; i < 200; i++) {
-    curTime += 10000; // +10ms
+    curTime += 11000; // +10ms
     rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
   }
 
@@ -1303,8 +1302,38 @@ TEST_F(RollerShutterTestsF, MoveDownWithSmallSteps) {
   EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
   EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
 
+  // +2000 ms 
+  for (int i = 0; i < 200; i++) {
+    curTime += 13000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  supla_esp_gpio_rs_add_task(0, 2);
+  EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
+ 
+  // +240 ms 
+  for (int i = 0; i < 18; i++) {
+    curTime += 13000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+  EXPECT_LT(*rsCfg->position, (100+ (2*100)));
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_TRUE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // +10 ms 
+  for (int i = 0; i < 2; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, (100+(2*100)));
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+
 }
-*/
 
 TEST_F(RollerShutterTestsF, TwoRelaysOnProblem) {
   uint32_t curTime = 100;

--- a/test/src/roller_shutter_tests.cpp
+++ b/test/src/roller_shutter_tests.cpp
@@ -1298,7 +1298,7 @@ TEST_F(RollerShutterTestsF, MoveDownWithSmallSteps) {
 
   EXPECT_EQ(rsCfg->up_time, 0);
   EXPECT_EQ(rsCfg->down_time, 0);
-  EXPECT_EQ(*rsCfg->position, (100+(1*100)));
+  EXPECT_NEAR(*rsCfg->position, (100+(1*100)), 10);
   EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
   EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
 
@@ -1321,14 +1321,14 @@ TEST_F(RollerShutterTestsF, MoveDownWithSmallSteps) {
   EXPECT_TRUE(eagleStub.getGpioValue(DOWN_GPIO));
 
   // +10 ms 
-  for (int i = 0; i < 2; i++) {
+  for (int i = 0; i < 5; i++) {
     curTime += 10000; // +10ms
     rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
   }
 
   EXPECT_EQ(rsCfg->up_time, 0);
   EXPECT_EQ(rsCfg->down_time, 0);
-  EXPECT_EQ(*rsCfg->position, (100+(2*100)));
+  EXPECT_NEAR(*rsCfg->position, (100+(2*100)), 10);
   EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
   EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
 


### PR DESCRIPTION
Fix #15 
Fixed problem with pretty random relay on time on small ~1% movements (relay could be swithched on for random periods of time from 0 to 300 ms), now it is more reliable and should work with ~10 ms precision (depending on ESP timer accuracy).
Added method for getting current RS position (in Supla server format) and adjusted relevant locations in code.
Fixed build.sh and check_compilation scripts, so they will really fail when compilation fails.