### PR TITLE
Roller shutter obstacle detection

### DIFF
--- a/src/user/supla_esp_devconn.c
+++ b/src/user/supla_esp_devconn.c
@@ -1841,3 +1841,11 @@ supla_esp_devconn_get_channel_int_params(unsigned char channel_number) {
   }
 }
 #endif /*BOARD_ON_CHANNEL_INT_PARAMS_RESULT*/
+
+// Method is used in tests to cleanup memory allocations
+void DEVCONN_ICACHE_FLASH supla_esp_devconn_release(void) {
+  supla_esp_devconn_stop();
+
+  free(devconn);
+  devconn = NULL;
+}

--- a/src/user/supla_esp_devconn.h
+++ b/src/user/supla_esp_devconn.h
@@ -31,6 +31,7 @@
 
 void DEVCONN_ICACHE_FLASH supla_esp_devconn_init(void);
 void DEVCONN_ICACHE_FLASH supla_esp_devconn_release(void);
+void DEVCONN_ICACHE_FLASH supla_esp_devconn_start(void);
 void DEVCONN_ICACHE_FLASH supla_esp_devconn_stop(void);
 char DEVCONN_ICACHE_FLASH supla_esp_devconn_is_registered(void);
 void DEVCONN_ICACHE_FLASH supla_esp_channel_value__changed(int channel_number, char value[SUPLA_CHANNELVALUE_SIZE]);

--- a/src/user/supla_esp_devconn.h
+++ b/src/user/supla_esp_devconn.h
@@ -108,5 +108,6 @@ supla_esp_devconn_get_channel_int_params(unsigned char channel_number);
 // moved to public interface for testing purposes
 void DEVCONN_ICACHE_FLASH
 supla_esp_channel_set_value(TSD_SuplaChannelNewValue *new_value);
+void DEVCONN_ICACHE_FLASH supla_esp_srpc_init(void);
 
 #endif /* SUPLA_ESP_CLIENT_H_ */

--- a/src/user/supla_esp_devconn.h
+++ b/src/user/supla_esp_devconn.h
@@ -30,7 +30,7 @@
 // ----------------------------------
 
 void DEVCONN_ICACHE_FLASH supla_esp_devconn_init(void);
-void DEVCONN_ICACHE_FLASH supla_esp_devconn_start(void);
+void DEVCONN_ICACHE_FLASH supla_esp_devconn_release(void);
 void DEVCONN_ICACHE_FLASH supla_esp_devconn_stop(void);
 char DEVCONN_ICACHE_FLASH supla_esp_devconn_is_registered(void);
 void DEVCONN_ICACHE_FLASH supla_esp_channel_value__changed(int channel_number, char value[SUPLA_CHANNELVALUE_SIZE]);

--- a/src/user/supla_esp_gpio.c
+++ b/src/user/supla_esp_gpio.c
@@ -76,7 +76,7 @@ void GPIO_ICACHE_FLASH supla_esp_gpio_rs_clear_flag(
 }
 
 #ifdef RS_AUTOCALIBRATION_SUPPORTED
-bool supla_esp_board_is_rs_in_move(supla_roller_shutter_cfg_t *rs_cfg);
+bool GPIO_ICACHE_FLASH supla_esp_board_is_rs_in_move(supla_roller_shutter_cfg_t *rs_cfg);
 #endif /*RS_AUTOCALIBRATION_SUPPORTED*/
 
 bool GPIO_ICACHE_FLASH supla_esp_gpio_is_rs_in_move(supla_roller_shutter_cfg_t *rs_cfg) {
@@ -141,7 +141,7 @@ sint8 GPIO_ICACHE_FLASH supla_esp_gpio_rs_get_current_position(
 }
 
 // calibration with manually provided times
-void supla_esp_gpio_rs_calibrate(supla_roller_shutter_cfg_t *rs_cfg,
+void GPIO_ICACHE_FLASH supla_esp_gpio_rs_calibrate(supla_roller_shutter_cfg_t *rs_cfg,
     unsigned int full_time, unsigned int time,
     int pos) {
 
@@ -156,6 +156,11 @@ void supla_esp_gpio_rs_calibrate(supla_roller_shutter_cfg_t *rs_cfg,
     }
   }
 }
+
+void GPIO_ICACHE_FLASH supla_esp_gpio_rs_check_motor(supla_roller_shutter_cfg_t *rs_cfg) {
+
+}
+
 
 #define RS_DIRECTION_NONE   0
 #define RS_DIRECTION_UP     2
@@ -172,7 +177,7 @@ void GPIO_ICACHE_FLASH supla_esp_gpio_rs_set_relay_delayed(void *timer_arg) {
   // TODO reset delayed_trigger.value to 0
 }
 
-void supla_esp_gpio_rs_set_relay(supla_roller_shutter_cfg_t *rs_cfg,
+void GPIO_ICACHE_FLASH supla_esp_gpio_rs_set_relay(supla_roller_shutter_cfg_t *rs_cfg,
     uint8 value, uint8 cancel_task,
     uint8 stop_delay) {
 	if ( rs_cfg == NULL ) {
@@ -286,7 +291,7 @@ supla_esp_gpio_rs_get_value(supla_roller_shutter_cfg_t *rs_cfg) {
 	return RS_RELAY_OFF;
 }
 
-void
+void GPIO_ICACHE_FLASH
 supla_esp_gpio_rs_move_position(supla_roller_shutter_cfg_t *rs_cfg, unsigned int full_time, unsigned int *time, uint8 up) {
 
 
@@ -367,14 +372,14 @@ supla_esp_gpio_rs_move_position(supla_roller_shutter_cfg_t *rs_cfg, unsigned int
 }
 
 
-uint8
+uint8 GPIO_ICACHE_FLASH
 supla_esp_gpio_rs_time_margin(supla_roller_shutter_cfg_t *rs_cfg, unsigned int full_time, unsigned int time, uint8 m) {
 
 	return  (full_time > 0 && ( time * 100 / full_time ) < m ) ? 1 : 0;
 
 }
 
-void
+void GPIO_ICACHE_FLASH
 supla_esp_gpio_rs_task_processing(supla_roller_shutter_cfg_t *rs_cfg) {
 	if ( rs_cfg->task.active == 0 || rs_cfg->autoCal_step > 0) {
 		return;
@@ -579,7 +584,7 @@ supla_esp_gpio_rs_autocalibrate(supla_roller_shutter_cfg_t *rs_cfg) {
   }
 }
 
-void supla_esp_gpio_rs_timer_cb(void *timer_arg) {
+void GPIO_ICACHE_FLASH supla_esp_gpio_rs_timer_cb(void *timer_arg) {
 
 	supla_roller_shutter_cfg_t *rs_cfg = (supla_roller_shutter_cfg_t*)timer_arg;
 
@@ -618,6 +623,7 @@ void supla_esp_gpio_rs_timer_cb(void *timer_arg) {
     supla_esp_gpio_rs_calibrate(rs_cfg, full_opening_time, rs_cfg->up_time, 100);
     supla_esp_gpio_rs_move_position(rs_cfg, full_opening_time, &rs_cfg->up_time,
         1);
+    supla_esp_gpio_rs_check_motor(rs_cfg);
 
   } else if (1 == __supla_esp_gpio_relay_is_hi(rs_cfg->down)) {
 
@@ -629,6 +635,7 @@ void supla_esp_gpio_rs_timer_cb(void *timer_arg) {
         10100);
     supla_esp_gpio_rs_move_position(rs_cfg, full_closing_time, 
         &rs_cfg->down_time, 0);
+    supla_esp_gpio_rs_check_motor(rs_cfg);
   } else {
     // if relays are off and we are not during autocal, then reset "calibration
     // in progress" flag

--- a/src/user/supla_esp_gpio.c
+++ b/src/user/supla_esp_gpio.c
@@ -439,17 +439,19 @@ bool GPIO_ICACHE_FLASH supla_esp_gpio_is_rs_in_move(supla_roller_shutter_cfg_t *
 #endif /*RS_AUTOCALIBRATION_SUPPORTED*/
 }
 
-void GPIO_ICACHE_FLASH supla_esp_gpio_rs_abort_calibration(supla_roller_shutter_cfg_t *rs_cfg) {
+void GPIO_ICACHE_FLASH
+supla_esp_gpio_rs_abort_calibration(supla_roller_shutter_cfg_t *rs_cfg) {
 
-          rs_cfg->autoCal_step = 0;
-          *rs_cfg->auto_opening_time = 0;
-          *rs_cfg->auto_closing_time = 0;
-          *rs_cfg->position = 0;
-          // off with cancel task
-          supla_esp_gpio_rs_set_relay(rs_cfg, RS_RELAY_OFF, 1, 0);
+  rs_cfg->autoCal_step = 0;
+  *rs_cfg->auto_opening_time = 0;
+  *rs_cfg->auto_closing_time = 0;
+  *rs_cfg->position = 0;
+  // off with cancel task
+  supla_esp_gpio_rs_set_relay(rs_cfg, RS_RELAY_OFF, 1, 0);
 }
 
-void GPIO_ICACHE_FLASH supla_esp_gpio_rs_autocalibrate(supla_roller_shutter_cfg_t *rs_cfg) {
+void GPIO_ICACHE_FLASH
+supla_esp_gpio_rs_autocalibrate(supla_roller_shutter_cfg_t *rs_cfg) {
   if (rs_cfg == NULL || rs_cfg->autoCal_step == 0) {
     return;
   }

--- a/src/user/supla_esp_gpio.c
+++ b/src/user/supla_esp_gpio.c
@@ -111,7 +111,7 @@ bool GPIO_ICACHE_FLASH supla_esp_gpio_rs_is_autocal_done(int idx) {
   if (idx < 0 || idx > RS_MAX_COUNT) {
     return false;
   }
-  return supla_esp_cfg.AutoCalOpenTime[idx] > 0 ||
+  return supla_esp_cfg.AutoCalOpenTime[idx] > 0 &&
     supla_esp_cfg.AutoCalCloseTime[idx] > 0;
 }
 

--- a/src/user/supla_esp_gpio.c
+++ b/src/user/supla_esp_gpio.c
@@ -61,6 +61,20 @@ static ETSTimer supla_gpio_timer2;
 unsigned char supla_esp_restart_on_cfg_press = 0;
 
 #ifdef _ROLLERSHUTTER_SUPPORT
+void GPIO_ICACHE_FLASH supla_esp_gpio_rs_set_flag(
+    supla_roller_shutter_cfg_t *rsCfg, unsigned _supla_int16_t flag) {
+  if (rsCfg) {
+    rsCfg->flags |= flag;
+  }
+}
+
+void GPIO_ICACHE_FLASH supla_esp_gpio_rs_clear_flag(
+    supla_roller_shutter_cfg_t *rsCfg, unsigned _supla_int16_t flag) {
+  if (rsCfg) {
+    rsCfg->flags &= ~flag;
+  }
+}
+
 int GPIO_ICACHE_FLASH
 supla_esp_gpio_rs_get_idx_by_ptr(supla_roller_shutter_cfg_t *rs_cfg) {
   for (int i = 0; i < RS_MAX_COUNT; i++) {
@@ -445,20 +459,6 @@ bool GPIO_ICACHE_FLASH supla_esp_gpio_is_rs_in_move(supla_roller_shutter_cfg_t *
 #else
   return false;
 #endif /*RS_AUTOCALIBRATION_SUPPORTED*/
-}
-
-void GPIO_ICACHE_FLASH supla_esp_gpio_rs_set_flag(
-    supla_roller_shutter_cfg_t *rsCfg, unsigned _supla_int16_t flag) {
-  if (rsCfg) {
-    rsCfg->flags |= flag;
-  }
-}
-
-void GPIO_ICACHE_FLASH supla_esp_gpio_rs_clear_flag(
-    supla_roller_shutter_cfg_t *rsCfg, unsigned _supla_int16_t flag) {
-  if (rsCfg) {
-    rsCfg->flags &= ~flag;
-  }
 }
 
 void GPIO_ICACHE_FLASH

--- a/src/user/supla_esp_gpio.h
+++ b/src/user/supla_esp_gpio.h
@@ -105,6 +105,9 @@ typedef struct {
   bool performAutoCalibration;
   bool autoCal_button_request;
 
+  unsigned _supla_int16_t flags;
+  unsigned _supla_int16_t last_flags;
+
 } supla_roller_shutter_cfg_t;
 
 extern supla_input_cfg_t supla_input_cfg[INPUT_MAX_COUNT];

--- a/src/user/supla_esp_gpio.h
+++ b/src/user/supla_esp_gpio.h
@@ -107,7 +107,7 @@ typedef struct {
 
   unsigned _supla_int16_t flags;
   unsigned _supla_int16_t last_flags;
-
+  bool detectedPowerConsumption;
 } supla_roller_shutter_cfg_t;
 
 extern supla_input_cfg_t supla_input_cfg[INPUT_MAX_COUNT];

--- a/test/doubles/srpc_mock.cpp
+++ b/test/doubles/srpc_mock.cpp
@@ -16,6 +16,7 @@
 
 #include "srpc_mock.h"
 #include <supla-common/srpc.h>
+#include <vector>
 
 _supla_int_t
 srpc_ds_async_channel_extendedvalue_changed(void *_srpc,
@@ -128,10 +129,9 @@ char srpc_output_dataexists(void *_srpc) {
 _supla_int_t srpc_ds_async_channel_value_changed(void *_srpc,
                                                  unsigned char channel_number,
                                                  char *value) {
-  assert(false);
   assert(SrpcInterface::instance);
-  return SrpcInterface::instance->srpc_ds_async_channel_value_changed(
-      _srpc, channel_number, value);
+  std::vector<char> vec(value, value + 8);
+  return SrpcInterface::instance->valueChanged(_srpc, channel_number, vec);
 }
 
 _supla_int_t srpc_ds_async_get_channel_functions(void *_srpc) {

--- a/test/doubles/srpc_mock.cpp
+++ b/test/doubles/srpc_mock.cpp
@@ -65,6 +65,7 @@ srpc_ds_async_device_calcfg_result(void *_srpc,
 
 void *srpc_init(TsrpcParams *params) {
   assert(SrpcInterface::instance);
+  SrpcInterface::instance->on_remote_call_received = params->on_remote_call_received;
   return SrpcInterface::instance->srpc_init(params);
 }
 
@@ -127,6 +128,7 @@ char srpc_output_dataexists(void *_srpc) {
 _supla_int_t srpc_ds_async_channel_value_changed(void *_srpc,
                                                  unsigned char channel_number,
                                                  char *value) {
+  assert(false);
   assert(SrpcInterface::instance);
   return SrpcInterface::instance->srpc_ds_async_channel_value_changed(
       _srpc, channel_number, value);
@@ -159,8 +161,14 @@ srpc_sd_async_get_firmware_update_url(void *_srpc,
                                                                         params);
 }
 
-SrpcInterface::SrpcInterface() { instance = this; }
+SrpcInterface::SrpcInterface() {
+  instance = this;
+  on_remote_call_received = nullptr;
+}
 
-SrpcInterface::~SrpcInterface() { instance = nullptr; }
+SrpcInterface::~SrpcInterface() {
+  instance = nullptr;
+  on_remote_call_received = nullptr;
+}
 
 SrpcInterface *SrpcInterface::instance = nullptr;

--- a/test/doubles/srpc_mock.h
+++ b/test/doubles/srpc_mock.h
@@ -32,6 +32,8 @@ public:
   valueChanged(void *srpc, unsigned char channelNumber, std::vector<char> value,
                unsigned char offline,
                unsigned _supla_int_t validity_time_sec) = 0;
+  virtual _supla_int_t valueChanged(void *srpc, unsigned char channelNumber,
+      std::vector<char> value) = 0;
 
   virtual _supla_int_t srpc_dcs_async_set_activity_timeout(
       void *_srpc, TDCS_SuplaSetActivityTimeout *dcs_set_activity_timeout) = 0;
@@ -58,9 +60,6 @@ public:
   virtual _supla_int_t srpc_dcs_async_get_user_localtime(void *_srpc) = 0;
   virtual unsigned char srpc_out_queue_item_count(void *srpc) = 0;
   virtual char srpc_output_dataexists(void *_srpc) = 0;
-  virtual _supla_int_t
-  srpc_ds_async_channel_value_changed(void *_srpc, unsigned char channel_number,
-                                      char *value) = 0;
   virtual _supla_int_t srpc_ds_async_get_channel_functions(void *_srpc) = 0;
   virtual _supla_int_t srpc_ds_async_channel_value_changed_b(void *_srpc, unsigned char channel_number, char *value, unsigned char offline) = 0;
   virtual void srpc_free(void *_srpc) = 0;
@@ -76,6 +75,8 @@ public:
               (void *, unsigned char, std::vector<char>, unsigned char,
                unsigned _supla_int_t),
               (override));
+  MOCK_METHOD(_supla_int_t, valueChanged,
+              (void *, unsigned char, std::vector<char>), (override));
   MOCK_METHOD(_supla_int_t, srpc_dcs_async_set_activity_timeout,
               (void *, TDCS_SuplaSetActivityTimeout *), (override));
   MOCK_METHOD(void, srpc_params_init, (TsrpcParams *), (override));
@@ -99,7 +100,6 @@ public:
               (override));
   MOCK_METHOD(unsigned char, srpc_out_queue_item_count, (void *), (override));
   MOCK_METHOD(char, srpc_output_dataexists, (void *), (override));
-  MOCK_METHOD(_supla_int_t, srpc_ds_async_channel_value_changed, (void *, unsigned char, char *), (override));
   MOCK_METHOD(_supla_int_t, srpc_ds_async_get_channel_functions, (void *), (override));
   MOCK_METHOD(_supla_int_t, srpc_ds_async_channel_value_changed_b, (void *, unsigned char, char *, unsigned char), (override));
   MOCK_METHOD(void, srpc_free, (void *), (override));

--- a/test/doubles/srpc_mock.h
+++ b/test/doubles/srpc_mock.h
@@ -67,6 +67,7 @@ public:
   virtual _supla_int_t srpc_sd_async_get_firmware_update_url(void *_srpc, TDS_FirmwareUpdateParams *params) = 0;
 
   static SrpcInterface *instance;
+  _func_srpc_event_OnRemoteCallReceived on_remote_call_received;
 };
 
 class SrpcMock : public SrpcInterface {

--- a/test/src/board_stub.c
+++ b/test/src/board_stub.c
@@ -23,6 +23,8 @@
 
 #include <supla_esp.h>
 
+#include <user_interface.h>
+
 const uint8_t rsa_public_key_bytes[RSA_NUM_BYTES];
 
 testBoardGpioInitCb *gpioInitCb = NULL;
@@ -41,13 +43,23 @@ void supla_esp_board_gpio_init(void) {
 };
 
 bool supla_esp_board_is_rs_in_move(supla_roller_shutter_cfg_t *rs_cfg) {
+
   assert(rs_cfg);
-  if (rs_cfg->up_time > 0 && rs_cfg->up_time < upTime) {
-    return true;
+  assert(rs_cfg->up_time == 0 || rs_cfg->down_time == 0);
+  unsigned int t = system_get_time();
+  if (rs_cfg->up_time == 0 && rs_cfg->down_time == 0) {
+    return false;
+  }
+  if (rs_cfg->up_time > 0) {
+    if (t - rs_cfg->start_time < upTime * 1000) {
+      return true;
+    }
   }
 
-  if (rs_cfg->down_time > 0 && rs_cfg->down_time < downTime) {
-    return true;
+  if (rs_cfg->down_time > 0) {
+    if (t - rs_cfg->start_time < downTime * 1000) {
+      return true;
+    }
   }
 
   return false;

--- a/test/src/board_stub.h
+++ b/test/src/board_stub.h
@@ -25,6 +25,7 @@ typedef void (testBoardGpioInitCb)(void);
 
 extern testBoardGpioInitCb *gpioInitCb;
 
+extern int startupTimeDelay;
 extern int upTime;
 extern int downTime;
 

--- a/test/src/roller_shutter_auto_cal_tests.cpp
+++ b/test/src/roller_shutter_auto_cal_tests.cpp
@@ -666,15 +666,9 @@ TEST_F(RollerShutterAutoCalWithSrpc, RsAutoCalibrated_SetNewPosition) {
   reqValue.DurationMS = (0) | (0 << 16);
   reqValue.value[0] = 30; // target posiotion = 20
 
-
-  // Move RS down.
-  EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
   // simulate request from server
   supla_esp_channel_set_value(&reqValue);
-  EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
 
-
-  // +2000 ms
   for (int i = 0; i < 200; i++) {
     curTime += 10000; // +10ms
     executeTimers();

--- a/test/src/roller_shutter_auto_cal_tests.cpp
+++ b/test/src/roller_shutter_auto_cal_tests.cpp
@@ -2998,3 +2998,4 @@ TEST_F(RollerShutterAutoCalWithSrpc, RsAutoCalibrated_CalibrationLostMoveDown) {
   EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
   EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
 }
+

--- a/test/src/roller_shutter_auto_cal_tests.cpp
+++ b/test/src/roller_shutter_auto_cal_tests.cpp
@@ -479,7 +479,7 @@ TEST_F(RollerShutterAutoCalWithSrpc,
   // Calibration started (proper flag added)
   char expectedValue4[8] = {};
   expectedValue4[0] = static_cast<char>(0xFF);
-  expectedValue4[3] = static_cast<char>(0x10); 
+  expectedValue4[3] = static_cast<char>(RS_VALUE_FLAG_CALIBRATION_IN_PROGRESS); 
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
     .WillOnce(Return(0));
 
@@ -790,7 +790,8 @@ TEST_F(RollerShutterAutoCalWithSrpc, RsNotCalibrated_TriggerAutoCalServerStop) {
 }
 
 // Button actions should not start calibration
-TEST_F(RollerShutterAutoCalWithSrpc, RsNotCalibrated_ButtonMovementsThenServerReq) {
+TEST_F(RollerShutterAutoCalWithSrpc,
+    RsNotCalibrated_ButtonMovementsThenServerReq) {
   int curTime = 10000; // start at +10 ms
   EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
 
@@ -802,7 +803,7 @@ TEST_F(RollerShutterAutoCalWithSrpc, RsNotCalibrated_ButtonMovementsThenServerRe
   // Calibration started (proper flag added)
   char expectedValue4[8] = {};
   expectedValue4[0] = static_cast<char>(0xFF);
-  expectedValue4[3] = static_cast<char>(0x10); 
+  expectedValue4[3] = static_cast<char>(RS_VALUE_FLAG_CALIBRATION_IN_PROGRESS);
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
     .WillOnce(Return(0));
 
@@ -1216,7 +1217,7 @@ TEST_F(RollerShutterAutoCalWithSrpc,
   // Calibration started (proper flag added)
   char expectedValue4[8] = {};
   expectedValue4[0] = static_cast<char>(0xFF);
-  expectedValue4[3] = static_cast<char>(0x10); 
+  expectedValue4[3] = static_cast<char>(RS_VALUE_FLAG_CALIBRATION_IN_PROGRESS); 
   {
     InSequence seq;
     EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue)))
@@ -2308,13 +2309,13 @@ TEST_F(RollerShutterAutoCalWithSrpc, AutoCalibrationFailedTooShortTime) {
   // Calibration started (proper flag added)
   char expectedValue4[8] = {};
   expectedValue4[0] = static_cast<char>(0xFF);
-  expectedValue4[3] = static_cast<char>(0x10); 
+  expectedValue4[3] = static_cast<char>(RS_VALUE_FLAG_CALIBRATION_IN_PROGRESS);
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
     .WillOnce(Return(0));
 
   char expectedValue2[8] = {};
   expectedValue2[0] = static_cast<char>(0xFF);
-  expectedValue2[3] = static_cast<char>(0x02); // calibration failed
+  expectedValue2[3] = static_cast<char>(RS_VALUE_FLAG_CALIBRATION_FAILED);
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue2)))
     .WillOnce(Return(0));
 
@@ -2398,7 +2399,7 @@ TEST_F(RollerShutterAutoCalWithSrpc, AutoCalibrationFailedTooShortTimeOnMoveUp) 
   // Calibration started (proper flag added)
   char expectedValue4[8] = {};
   expectedValue4[0] = static_cast<char>(0xFF);
-  expectedValue4[3] = static_cast<char>(0x10); 
+  expectedValue4[3] = static_cast<char>(RS_VALUE_FLAG_CALIBRATION_IN_PROGRESS);
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
     .Times(2)
     .WillRepeatedly(Return(0));
@@ -2406,7 +2407,7 @@ TEST_F(RollerShutterAutoCalWithSrpc, AutoCalibrationFailedTooShortTimeOnMoveUp) 
   // First calibration fails
   char expectedValue2[8] = {};
   expectedValue2[0] = static_cast<char>(0xFF);
-  expectedValue2[3] = static_cast<char>(0x02); // calibration failed
+  expectedValue2[3] = static_cast<char>(RS_VALUE_FLAG_CALIBRATION_FAILED);
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue2)))
     .WillOnce(Return(0));
 
@@ -2515,13 +2516,13 @@ TEST_F(RollerShutterAutoCalWithSrpc, AutoCalibrationFailedTooLongTime) {
   // Calibration started (proper flag added)
   char expectedValue4[8] = {};
   expectedValue4[0] = static_cast<char>(0xFF);
-  expectedValue4[3] = static_cast<char>(0x10); 
+  expectedValue4[3] = static_cast<char>(RS_VALUE_FLAG_CALIBRATION_IN_PROGRESS);
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
     .WillOnce(Return(0));
 
   char expectedValue2[8] = {};
   expectedValue2[0] = static_cast<char>(0xFF);
-  expectedValue2[3] = static_cast<char>(0x02); // calibration failed
+  expectedValue2[3] = static_cast<char>(RS_VALUE_FLAG_CALIBRATION_FAILED);
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue2)))
     .WillOnce(Return(0));
 
@@ -2597,13 +2598,13 @@ TEST_F(RollerShutterAutoCalWithSrpc, AutoCalibrationFailedTooLongDownTime) {
   // Calibration started (proper flag added)
   char expectedValue4[8] = {};
   expectedValue4[0] = static_cast<char>(0xFF);
-  expectedValue4[3] = static_cast<char>(0x10); 
+  expectedValue4[3] = static_cast<char>(RS_VALUE_FLAG_CALIBRATION_IN_PROGRESS);
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
     .WillOnce(Return(0));
 
   char expectedValue2[8] = {};
   expectedValue2[0] = static_cast<char>(0xFF);
-  expectedValue2[3] = static_cast<char>(0x02); // calibration failed
+  expectedValue2[3] = static_cast<char>(RS_VALUE_FLAG_CALIBRATION_FAILED);
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue2)))
     .WillOnce(Return(0));
 
@@ -2688,7 +2689,7 @@ TEST_F(RollerShutterAutoCalWithSrpc, RsAutoCalibrated_CalibrationLost) {
 
   char expectedValue4[8] = {};
   expectedValue4[0] = static_cast<char>(100);
-  expectedValue4[3] = static_cast<char>(0x08); // calibration lost
+  expectedValue4[3] = static_cast<char>(RS_VALUE_FLAG_CALIBRATION_LOST); // calibration lost
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
     .WillOnce(Return(0));
 
@@ -2768,8 +2769,10 @@ TEST_F(RollerShutterAutoCalWithSrpc, RsAutoCalibrated_CalibrationLostPos0) {
     .WillRepeatedly(Return(0));
 
 
-  EXPECT_CALL(srpc, 
-      valueChanged(_, 0, ElementsAreArray({0, 0, 0, 0x08, 0, 0, 0, 0})))
+  EXPECT_CALL(srpc, valueChanged(_, 0,
+        ElementsAreArray({0, 0, 0,
+          RS_VALUE_FLAG_CALIBRATION_LOST,
+          0, 0, 0, 0})))
     .WillOnce(Return(0));
 
   supla_esp_cfg.Time1[0] = 0;
@@ -2848,8 +2851,10 @@ TEST_F(RollerShutterAutoCalWithSrpc, RsAutoCalibrated_CalibrationLostMoveUp) {
     .WillRepeatedly(Return(0));
 
 
-  EXPECT_CALL(srpc, 
-      valueChanged(_, 0, ElementsAreArray({0, 0, 0, 0x08, 0, 0, 0, 0})))
+  EXPECT_CALL(srpc, valueChanged(_, 0,
+        ElementsAreArray({0, 0, 0,
+          RS_VALUE_FLAG_CALIBRATION_LOST,
+          0, 0, 0, 0})))
     .WillOnce(Return(0));
 
   supla_esp_cfg.Time1[0] = 0;
@@ -2936,8 +2941,10 @@ TEST_F(RollerShutterAutoCalWithSrpc, RsAutoCalibrated_CalibrationLostMoveDown) {
     .WillRepeatedly(Return(0));
 
 
-  EXPECT_CALL(srpc, 
-      valueChanged(_, 0, ElementsAreArray({100, 0, 0, 0x08, 0, 0, 0, 0})))
+  EXPECT_CALL(srpc, valueChanged(_, 0,
+        ElementsAreArray({100, 0, 0,
+          RS_VALUE_FLAG_CALIBRATION_LOST,
+          0, 0, 0, 0})))
     .WillOnce(Return(0));
 
   supla_esp_cfg.Time1[0] = 0;
@@ -3017,7 +3024,7 @@ TEST_F(RollerShutterAutoCalWithSrpc, AutoCalibrationWithLongStartupTime) {
   // Calibration started (proper flag added)
   char expectedValue4[8] = {};
   expectedValue4[0] = static_cast<char>(0xFF);
-  expectedValue4[3] = static_cast<char>(0x10); 
+  expectedValue4[3] = static_cast<char>(RS_VALUE_FLAG_CALIBRATION_IN_PROGRESS); 
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
     .WillOnce(Return(0));
 

--- a/test/src/roller_shutter_auto_cal_tests.cpp
+++ b/test/src/roller_shutter_auto_cal_tests.cpp
@@ -19,6 +19,8 @@
 #include <eagle_soc_stub.h>
 #include <gtest/gtest.h>
 #include <time_mock.h>
+#include <srpc_mock.h>
+#include <uptime_stub.h>
 
 extern "C" {
 #include "board_stub.h"
@@ -40,6 +42,11 @@ using ::testing::InSequence;
 using ::testing::Return;
 using ::testing::ReturnPointee;
 using ::testing::SaveArg;
+using ::testing::DoAll;
+using ::testing::SetArgPointee;
+using ::testing::Invoke;
+using ::testing::Pointee;
+using ::testing::ElementsAreArray;
 
 // method will be called by supla_esp_gpio_init method in order to initialize
 // gpio input/outputs board configuration (supla_esb_board_gpio_init)
@@ -59,6 +66,15 @@ void gpioCallback2() {
   supla_rs_cfg[0].delayed_trigger.value = 0;
 }
 
+TSD_SuplaRegisterDeviceResult regResultAutoCal;
+
+char custom_srpc_getdata_auto_cal(void *_srpc, TsrpcReceivedData *rd,
+    unsigned _supla_int_t rr_id) {
+  rd->call_type = SUPLA_SD_CALL_REGISTER_DEVICE_RESULT;
+  rd->data.sd_register_device_result = &regResultAutoCal;
+  return 1;
+}
+
 class RollerShutterAutoCalF : public ::testing::Test {
 public:
   TimeMock time;
@@ -75,6 +91,7 @@ public:
   }
 
   void TearDown() override {
+    supla_esp_devconn_release();
     upTime = 1100;
     downTime = 1200;
     memset(&supla_esp_cfg, 0, sizeof(supla_esp_cfg));
@@ -85,6 +102,61 @@ public:
     gpioInitCb = nullptr;
   }
 };
+
+class RollerShutterAutoCalWithSrpc : public ::testing::Test {
+public:
+  SrpcMock srpc;
+  UptimeStub uptime;
+  TimeMock time;
+  EagleSocStub eagleStub;
+  int curTime;
+
+  void SetUp() override {
+    upTime = 1100;
+    downTime = 1200;
+    memset(&supla_esp_cfg, 0, sizeof(supla_esp_cfg));
+    memset(&supla_esp_state, 0, sizeof(SuplaEspState));
+    cleanupTimers();
+    supla_esp_gpio_init_time = 0;
+    gpioInitCb = *gpioCallback2;
+    curTime = 10000; // start at +10 ms
+    EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
+
+    EXPECT_CALL(srpc, srpc_params_init(_));
+    EXPECT_CALL(srpc, srpc_init(_)).WillOnce(Return((void *)1));
+    EXPECT_CALL(srpc, srpc_set_proto_version(_, 15));
+
+    regResultAutoCal.result_code = SUPLA_RESULTCODE_TRUE;
+
+    EXPECT_CALL(srpc, srpc_getdata(_, _, _))
+      .WillOnce(DoAll(Invoke(custom_srpc_getdata_auto_cal), Return(1)));
+    EXPECT_CALL(srpc, srpc_rd_free(_));
+    EXPECT_CALL(srpc, srpc_free(_));
+    EXPECT_CALL(srpc, srpc_iterate(_)).WillRepeatedly(Return(SUPLA_RESULT_TRUE));
+    EXPECT_CALL(srpc, srpc_dcs_async_set_activity_timeout(_, _));
+
+    supla_esp_devconn_init();
+    supla_esp_srpc_init();
+    ASSERT_NE(srpc.on_remote_call_received, nullptr);
+
+    srpc.on_remote_call_received((void *)1, 0, 0, nullptr, 0);
+    EXPECT_EQ(supla_esp_devconn_is_registered(), 1);
+
+  }
+
+  void TearDown() override {
+    supla_esp_devconn_release();
+    upTime = 1100;
+    downTime = 1200;
+    memset(&supla_esp_cfg, 0, sizeof(supla_esp_cfg));
+    memset(&supla_esp_state, 0, sizeof(SuplaEspState));
+    supla_esp_gpio_init_time = 0;
+    cleanupTimers();
+
+    gpioInitCb = nullptr;
+  }
+};
+
 
 // method will be called by supla_esp_gpio_init method in order to initialize
 // gpio input/outputs board configuration (supla_esb_board_gpio_init)
@@ -166,6 +238,7 @@ public:
   }
 
   void TearDown() override {
+    supla_esp_devconn_release();
     upTime = 1100;
     downTime = 1200;
     memset(&supla_esp_cfg, 0, sizeof(supla_esp_cfg));
@@ -177,9 +250,14 @@ public:
   }
 };
 
-TEST_F(RollerShutterAutoCalF, RsNotCalibrated_ServerReqRelayDown) {
+TEST_F(RollerShutterAutoCalWithSrpc, RsNotCalibrated_ServerReqRelayDown) {
   int curTime = 10000; // start at +10 ms
   EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
+
+  char expectedValue[8] = {};
+  expectedValue[0] = static_cast<char>(0xFF);
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue)))
+    .WillOnce(Return(0));
 
   supla_esp_gpio_init();
 
@@ -375,7 +453,7 @@ TEST_F(RollerShutterAutoCalF, RsManuallyCalibrated_EnableAutoCal) {
   EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
 }
 
-TEST_F(RollerShutterAutoCalF,
+TEST_F(RollerShutterAutoCalWithSrpc,
     RsManuallyCalibrated_ApplyAnotherManualCalibration) {
   int curTime = 10000; // start at +10 ms
   EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
@@ -383,6 +461,27 @@ TEST_F(RollerShutterAutoCalF,
   supla_esp_cfg.Time1[0] = 1000;
   supla_esp_cfg.Time2[0] = 1000;
   supla_esp_state.rs_position[0] = 200;
+
+  // called twice - once by rs timers, second time as a result of device 
+  // registration delayed callback
+  char expectedValue[8] = {};
+  expectedValue[0] = static_cast<char>(1);
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue)))
+    .Times(2)
+    .WillRepeatedly(Return(0));
+ 
+  // Calibration started (proper flag added)
+  char expectedValue4[8] = {};
+  expectedValue4[0] = static_cast<char>(0xFF);
+  expectedValue4[3] = static_cast<char>(0x10); 
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
+    .WillOnce(Return(0));
+
+  char expectedValue3[8] = {};
+  expectedValue3[0] = static_cast<char>(100);
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue3)))
+    .WillOnce(Return(0));
+ 
   supla_esp_gpio_init();
 
   supla_roller_shutter_cfg_t *rsCfg = supla_esp_gpio_get_rs__cfg(1);
@@ -412,7 +511,7 @@ TEST_F(RollerShutterAutoCalF,
   // closing and opening time is coded in 0.1s units on 2x16 bit blocks of
   // DurationMS
   // In autocalibration, server sends ct/ot == 0
-  reqValue.DurationMS = (10) | (0 << 16);
+  reqValue.DurationMS = (10) | (20 << 16);
   reqValue.value[0] = 1; //RS_RELAY_DOWN
 
   // Move RS down.
@@ -421,17 +520,23 @@ TEST_F(RollerShutterAutoCalF,
   supla_esp_channel_set_value(&reqValue);
   EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
 
+  // +5000 ms
+  for (int i = 0; i < 500; i++) {
+    curTime += 10000; // +10ms
+    executeTimers();
+  }
+
   EXPECT_EQ(rsCfg->up_time, 0);
   EXPECT_EQ(rsCfg->down_time, 0);
-  EXPECT_EQ(*rsCfg->position, 0);
-  EXPECT_EQ(*rsCfg->full_opening_time, 0);
+  EXPECT_EQ(*rsCfg->position, 10100);
+  EXPECT_EQ(*rsCfg->full_opening_time, 2000);
   EXPECT_EQ(*rsCfg->full_closing_time, 1000);
-  EXPECT_EQ(supla_esp_cfg.Time1[0], 0);
+  EXPECT_EQ(supla_esp_cfg.Time1[0], 2000);
   EXPECT_EQ(supla_esp_cfg.Time2[0], 1000);
   EXPECT_EQ(supla_esp_cfg.AutoCalOpenTime[0], 0);
   EXPECT_EQ(supla_esp_cfg.AutoCalCloseTime[0], 0);
   EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
-  EXPECT_TRUE(eagleStub.getGpioValue(DOWN_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
 }
 
 TEST_F(RollerShutterAutoCalF, RsAutoCalibrated_DisableAutoCal) {
@@ -554,10 +659,15 @@ TEST_F(RollerShutterAutoCalF, RsAutoCalibrated_SetNewPosition) {
   EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
 }
 
-TEST_F(RollerShutterAutoCalF, RsNotCalibrated_TriggerAutoCalServerStop) {
+TEST_F(RollerShutterAutoCalWithSrpc, RsNotCalibrated_TriggerAutoCalServerStop) {
   int curTime = 10000; // start at +10 ms
   EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
 
+  char expectedValue[8] = {};
+  expectedValue[0] = static_cast<char>(0xFF);
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue)))
+    .WillOnce(Return(0));
+ 
   supla_esp_gpio_init();
 
   supla_roller_shutter_cfg_t *rsCfg = supla_esp_gpio_get_rs__cfg(1);
@@ -621,9 +731,47 @@ TEST_F(RollerShutterAutoCalF, RsNotCalibrated_TriggerAutoCalServerStop) {
 }
 
 // Button actions should not start calibration
-TEST_F(RollerShutterAutoCalF, RsNotCalibrated_ButtonMovementsThenServerReq) {
+TEST_F(RollerShutterAutoCalWithSrpc, RsNotCalibrated_ButtonMovementsThenServerReq) {
   int curTime = 10000; // start at +10 ms
   EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
+
+  char expectedValue[8] = {};
+  expectedValue[0] = static_cast<char>(0xFF);
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue)))
+    .WillOnce(Return(0));
+ 
+  // Calibration started (proper flag added)
+  char expectedValue4[8] = {};
+  expectedValue4[0] = static_cast<char>(0xFF);
+  expectedValue4[3] = static_cast<char>(0x10); 
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
+    .WillOnce(Return(0));
+
+  char expectedValue2[8] = {};
+  expectedValue2[0] = static_cast<char>(0x00);
+  expectedValue2[3] = static_cast<char>(0x00);
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue2)))
+    .WillOnce(Return(0));
+
+
+  // after calibration we set position 80 (intermediate step 6)
+  char expectedValue5[8] = {};
+  expectedValue5[0] = static_cast<char>(0x06);
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue5)))
+    .WillOnce(Return(0));
+
+  // after calibration we set position 80 (intermediate step 53)
+  char expectedValue6[8] = {};
+  expectedValue6[0] = static_cast<char>(53);
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue6)))
+    .WillOnce(Return(0));
+
+  // after calibration we set position 80
+  char expectedValue7[8] = {};
+  expectedValue7[0] = static_cast<char>(80);
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue7)))
+    .WillOnce(Return(0));
+
 
   supla_esp_gpio_init();
 
@@ -997,12 +1145,28 @@ TEST_F(RollerShutterAutoCalF,
   EXPECT_EQ(rsCfg->autoCal_step, 0);
 }
 
-TEST_F(RollerShutterAutoCalF,
+TEST_F(RollerShutterAutoCalWithSrpc,
     RsNotCalibrated_TriggerAutoCalAndAbortByButton) {
   // add task may be executed i.e. in mqtt
   
   int curTime = 10000; // start at +10 ms
   EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
+
+  char expectedValue[8] = {};
+  expectedValue[0] = static_cast<char>(0xFF);
+  // Calibration started (proper flag added)
+  char expectedValue4[8] = {};
+  expectedValue4[0] = static_cast<char>(0xFF);
+  expectedValue4[3] = static_cast<char>(0x10); 
+  {
+    InSequence seq;
+    EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue)))
+      .WillOnce(Return(0));
+    EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
+      .WillOnce(Return(0));
+    EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue)))
+      .WillOnce(Return(0));
+  }
 
   supla_esp_gpio_init();
 
@@ -2068,7 +2232,7 @@ TEST_F(RollerShutterAutoCalF, SwitchToAutoCalibrationDuringMoveDown) {
 
 }
 
-TEST_F(RollerShutterAutoCalF, AutoCalibrationFailedTooShortTime) {
+TEST_F(RollerShutterAutoCalWithSrpc, AutoCalibrationFailedTooShortTime) {
   int curTime = 10000; // start at +10 ms
   EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
 
@@ -2077,6 +2241,24 @@ TEST_F(RollerShutterAutoCalF, AutoCalibrationFailedTooShortTime) {
   upTime = 400;
   downTime = 400;
 
+  char expectedValue[8] = {};
+  expectedValue[0] = static_cast<char>(0xFF);
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue)))
+    .WillOnce(Return(0));
+
+  // Calibration started (proper flag added)
+  char expectedValue4[8] = {};
+  expectedValue4[0] = static_cast<char>(0xFF);
+  expectedValue4[3] = static_cast<char>(0x10); 
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
+    .WillOnce(Return(0));
+
+  char expectedValue2[8] = {};
+  expectedValue2[0] = static_cast<char>(0xFF);
+  expectedValue2[3] = static_cast<char>(0x02); // calibration failed
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue2)))
+    .WillOnce(Return(0));
+
   supla_esp_gpio_init();
 
   supla_roller_shutter_cfg_t *rsCfg = supla_esp_gpio_get_rs__cfg(1);
@@ -2135,7 +2317,7 @@ TEST_F(RollerShutterAutoCalF, AutoCalibrationFailedTooShortTime) {
 
 }
 
-TEST_F(RollerShutterAutoCalF, AutoCalibrationFailedTooShortTimeOnMoveUp) {
+TEST_F(RollerShutterAutoCalWithSrpc, AutoCalibrationFailedTooShortTimeOnMoveUp) {
   int curTime = 10000; // start at +10 ms
   EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
 
@@ -2144,6 +2326,38 @@ TEST_F(RollerShutterAutoCalF, AutoCalibrationFailedTooShortTimeOnMoveUp) {
   upTime = 400;
   downTime = 800;
 
+  // not calibrated/calibration in progress
+  // This will be called at the begining of calibration procedure
+  // So we expect it twice
+  char expectedValue[8] = {};
+  expectedValue[0] =
+    static_cast<char>(0xFF); // calibration in progress/not calibrated
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue)))
+    .Times(1)
+    .WillRepeatedly(Return(0));
+
+  // Calibration started (proper flag added)
+  char expectedValue4[8] = {};
+  expectedValue4[0] = static_cast<char>(0xFF);
+  expectedValue4[3] = static_cast<char>(0x10); 
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
+    .Times(2)
+    .WillRepeatedly(Return(0));
+
+  // First calibration fails
+  char expectedValue2[8] = {};
+  expectedValue2[0] = static_cast<char>(0xFF);
+  expectedValue2[3] = static_cast<char>(0x02); // calibration failed
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue2)))
+    .WillOnce(Return(0));
+
+  // Second calibration is sucessful
+  char expectedValue3[8] = {};
+  expectedValue3[0] = static_cast<char>(0x00);
+  expectedValue3[3] = static_cast<char>(0x00); // calibration successful
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue3)))
+    .WillOnce(Return(0));
+
   supla_esp_gpio_init();
 
   supla_roller_shutter_cfg_t *rsCfg = supla_esp_gpio_get_rs__cfg(1);
@@ -2184,7 +2398,7 @@ TEST_F(RollerShutterAutoCalF, AutoCalibrationFailedTooShortTimeOnMoveUp) {
   EXPECT_EQ(*rsCfg->full_closing_time, 0);
 
   // Calibration 
-  for (int i = 0; i < 400; i++) {
+  for (int i = 0; i < 800; i++) {
     curTime += 10000; // +10ms
     executeTimers();
   }
@@ -2199,16 +2413,58 @@ TEST_F(RollerShutterAutoCalF, AutoCalibrationFailedTooShortTimeOnMoveUp) {
   EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
   EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
   EXPECT_EQ(rsCfg->autoCal_step, 0);
+
+// Second calibration attempt should be successful and should clear error flags
+  // Set how long [ms] "is_in_move" method will return true
+  // auto cal times < 500 ms are considered as errors
+  upTime = 1100;
+  downTime = 1200;
+
+  reqValue.value[0] = 10; // position 0
+  supla_esp_channel_set_value(&reqValue);
+  // Calibration 
+  for (int i = 0; i < 800; i++) {
+    curTime += 10000; // +10ms
+    executeTimers();
+  }
+
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, 100);
+  EXPECT_EQ(*rsCfg->full_opening_time, 0);
+  EXPECT_EQ(*rsCfg->full_closing_time, 0);
+  EXPECT_EQ(supla_esp_cfg.AutoCalOpenTime[0], 1100);
+  EXPECT_EQ(supla_esp_cfg.AutoCalCloseTime[0], 1200);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+  EXPECT_EQ(rsCfg->autoCal_step, 0);
+
 }
 
-TEST_F(RollerShutterAutoCalF, AutoCalibrationFailedTooLongTime) {
-  int curTime = 10000; // start at +10 ms
-  EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
+TEST_F(RollerShutterAutoCalWithSrpc, AutoCalibrationFailedTooLongTime) {
 
   // Set how long [ms] "is_in_move" method will return true
   // auto cal times > 600000 (10 min) are considered as errors
   upTime = 700000;
   downTime = 700000;
+
+  char expectedValue[8] = {};
+  expectedValue[0] = static_cast<char>(0xFF);
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue)))
+    .WillOnce(Return(0));
+ 
+  // Calibration started (proper flag added)
+  char expectedValue4[8] = {};
+  expectedValue4[0] = static_cast<char>(0xFF);
+  expectedValue4[3] = static_cast<char>(0x10); 
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
+    .WillOnce(Return(0));
+
+  char expectedValue2[8] = {};
+  expectedValue2[0] = static_cast<char>(0xFF);
+  expectedValue2[3] = static_cast<char>(0x02); // calibration failed
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue2)))
+    .WillOnce(Return(0));
 
   supla_esp_gpio_init();
 
@@ -2267,14 +2523,30 @@ TEST_F(RollerShutterAutoCalF, AutoCalibrationFailedTooLongTime) {
   EXPECT_EQ(rsCfg->autoCal_step, 0);
 }
 
-TEST_F(RollerShutterAutoCalF, AutoCalibrationFailedTooLongDownTime) {
-  int curTime = 10000; // start at +10 ms
-  EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
+TEST_F(RollerShutterAutoCalWithSrpc, AutoCalibrationFailedTooLongDownTime) {
 
   // Set how long [ms] "is_in_move" method will return true
   // auto cal times > 600000 (10 min) are considered as errors
   upTime = 7000;
   downTime = 700000;
+
+  char expectedValue[8] = {};
+  expectedValue[0] = static_cast<char>(0xFF);
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue)))
+    .WillOnce(Return(0));
+ 
+  // Calibration started (proper flag added)
+  char expectedValue4[8] = {};
+  expectedValue4[0] = static_cast<char>(0xFF);
+  expectedValue4[3] = static_cast<char>(0x10); 
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue4)))
+    .WillOnce(Return(0));
+
+  char expectedValue2[8] = {};
+  expectedValue2[0] = static_cast<char>(0xFF);
+  expectedValue2[3] = static_cast<char>(0x02); // calibration failed
+  EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue2)))
+    .WillOnce(Return(0));
 
   supla_esp_gpio_init();
 

--- a/test/src/roller_shutter_calcfg_tests.cpp
+++ b/test/src/roller_shutter_calcfg_tests.cpp
@@ -71,6 +71,7 @@ public:
   void SetUp() override {
     curTime = 10000; // start at +10 ms
     EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
+    startupTimeDelay = 0;
     upTime = 1100;
     downTime = 1200;
     memset(&supla_esp_cfg, 0, sizeof(supla_esp_cfg));
@@ -81,6 +82,7 @@ public:
   }
 
   void TearDown() override {
+    startupTimeDelay = 0;
     upTime = 1100;
     downTime = 1200;
     *supla_rs_cfg[0].position = 0;

--- a/test/src/roller_shutter_motor_problem_tests.cpp
+++ b/test/src/roller_shutter_motor_problem_tests.cpp
@@ -148,7 +148,7 @@ TEST_F(RollerShutterMotorProblem, MotorProblemMoveDown) {
     .WillRepeatedly(Return(0));
 
   EXPECT_CALL(srpc, 
-      valueChanged(_, 0, ElementsAreArray({100, 0, 0, 0x04, 0, 0, 0, 0})))
+      valueChanged(_, 0, ElementsAreArray({100, 0, 0, RS_VALUE_FLAG_MOTOR_PROBLEM, 0, 0, 0, 0})))
     .WillOnce(Return(0));
 
   supla_esp_cfg.Time1[0] = 0;
@@ -220,8 +220,10 @@ TEST_F(RollerShutterMotorProblem, MotorProblemMoveUp) {
       valueChanged(_, 0, ElementsAreArray({47, 0, 0, 0, 0, 0, 0, 0})))
     .WillRepeatedly(Return(0));
 
-  EXPECT_CALL(srpc, 
-      valueChanged(_, 0, ElementsAreArray({0, 0, 0, 0x04, 0, 0, 0, 0})))
+  EXPECT_CALL(srpc,
+      valueChanged(_, 0,
+        ElementsAreArray({0, 0, 0, RS_VALUE_FLAG_MOTOR_PROBLEM,
+          0, 0, 0, 0})))
     .WillOnce(Return(0));
 
   supla_esp_cfg.Time1[0] = 0;
@@ -439,8 +441,10 @@ TEST_F(RollerShutterMotorProblem, MotorProblemByTask) {
       valueChanged(_, 0, ElementsAreArray({52, 0, 0, 0, 0, 0, 0, 0})))
     .WillOnce(Return(0));
 
-  EXPECT_CALL(srpc, 
-      valueChanged(_, 0, ElementsAreArray({90, 0, 0, 0x04, 0, 0, 0, 0})))
+  EXPECT_CALL(srpc, valueChanged(_, 0,
+        ElementsAreArray({90, 0, 0,
+          RS_VALUE_FLAG_MOTOR_PROBLEM, 0,
+          0, 0, 0})))
     .WillOnce(Return(0));
 
   supla_esp_cfg.Time1[0] = 0;
@@ -514,12 +518,16 @@ TEST_F(RollerShutterMotorProblem, MotorProblemWithLongStartupTime) {
     .Times(2)
     .WillRepeatedly(Return(0));
 
-  EXPECT_CALL(srpc, 
-      valueChanged(_, 0, ElementsAreArray({53, 0, 0, 0x04, 0, 0, 0, 0})))
+  EXPECT_CALL(srpc, valueChanged(_, 0,
+        ElementsAreArray({53, 0, 0,
+          RS_VALUE_FLAG_MOTOR_PROBLEM, 0,
+          0, 0, 0})))
     .WillOnce(Return(0));
 
-  EXPECT_CALL(srpc, 
-      valueChanged(_, 0, ElementsAreArray({90, 0, 0, 0x04, 0, 0, 0, 0})))
+  EXPECT_CALL(srpc, valueChanged(_, 0,
+        ElementsAreArray({90, 0, 0,
+          RS_VALUE_FLAG_MOTOR_PROBLEM, 0,
+          0, 0, 0})))
     .WillOnce(Return(0));
 
   supla_esp_cfg.Time1[0] = 0;

--- a/test/src/roller_shutter_motor_problem_tests.cpp
+++ b/test/src/roller_shutter_motor_problem_tests.cpp
@@ -1,0 +1,497 @@
+/* Copyright (C) AC SOFTWARE SP. Z O.O.
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include <eagle_soc_mock.h>
+#include <eagle_soc_stub.h>
+#include <gtest/gtest.h>
+#include <time_mock.h>
+#include <srpc_mock.h>
+#include <uptime_stub.h>
+
+extern "C" {
+#include "board_stub.h"
+#include <osapi.h>
+#include <supla_esp_cfg.h>
+#include <supla_esp_gpio.h>
+#include <supla_esp_devconn.h>
+}
+
+#define RS_DIRECTION_NONE 0
+#define RS_DIRECTION_UP 2
+#define RS_DIRECTION_DOWN 1
+
+#define UP_GPIO 1
+#define DOWN_GPIO 2
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::Return;
+using ::testing::ReturnPointee;
+using ::testing::SaveArg;
+using ::testing::DoAll;
+using ::testing::SetArgPointee;
+using ::testing::Invoke;
+using ::testing::Pointee;
+using ::testing::ElementsAreArray;
+
+// method will be called by supla_esp_gpio_init method in order to initialize
+// gpio input/outputs board configuration (supla_esb_board_gpio_init)
+void gpioCallbackMotor() {
+  // up
+  supla_relay_cfg[0].gpio_id = UP_GPIO;
+  supla_relay_cfg[0].channel = 0;
+  supla_relay_cfg[0].channel_flags = SUPLA_CHANNEL_FLAG_RS_AUTO_CALIBRATION;
+
+  // down
+  supla_relay_cfg[1].gpio_id = DOWN_GPIO;
+  supla_relay_cfg[1].channel = 0;
+  supla_relay_cfg[1].channel_flags = SUPLA_CHANNEL_FLAG_RS_AUTO_CALIBRATION;
+
+  supla_rs_cfg[0].up = &supla_relay_cfg[0];
+  supla_rs_cfg[0].down = &supla_relay_cfg[1];
+  supla_rs_cfg[0].delayed_trigger.value = 0;
+}
+
+TSD_SuplaRegisterDeviceResult regResultMotor;
+
+char custom_srpc_getdata_motor_problem(void *_srpc, TsrpcReceivedData *rd,
+    unsigned _supla_int_t rr_id) {
+  rd->call_type = SUPLA_SD_CALL_REGISTER_DEVICE_RESULT;
+  rd->data.sd_register_device_result = &regResultMotor;
+  return 1;
+}
+
+class RollerShutterMotorProblem : public ::testing::Test {
+public:
+  SrpcMock srpc;
+  UptimeStub uptime;
+  TimeMock time;
+  EagleSocStub eagleStub;
+  int curTime;
+
+  void SetUp() override {
+    upTime = 1100;
+    downTime = 1200;
+    memset(&supla_esp_cfg, 0, sizeof(supla_esp_cfg));
+    memset(&supla_esp_state, 0, sizeof(SuplaEspState));
+    cleanupTimers();
+    supla_esp_gpio_init_time = 0;
+    gpioInitCb = *gpioCallbackMotor;
+    curTime = 10000; // start at +10 ms
+    EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
+
+    EXPECT_CALL(srpc, srpc_params_init(_));
+    EXPECT_CALL(srpc, srpc_init(_)).WillOnce(Return((void *)1));
+    EXPECT_CALL(srpc, srpc_set_proto_version(_, 15));
+
+    regResultMotor.result_code = SUPLA_RESULTCODE_TRUE;
+
+    EXPECT_CALL(srpc, srpc_getdata(_, _, _))
+      .WillOnce(DoAll(Invoke(custom_srpc_getdata_motor_problem), Return(1)));
+    EXPECT_CALL(srpc, srpc_rd_free(_));
+    EXPECT_CALL(srpc, srpc_free(_));
+    EXPECT_CALL(srpc, srpc_iterate(_)).WillRepeatedly(Return(SUPLA_RESULT_TRUE));
+    EXPECT_CALL(srpc, srpc_dcs_async_set_activity_timeout(_, _));
+
+    supla_esp_devconn_init();
+    supla_esp_srpc_init();
+    ASSERT_NE(srpc.on_remote_call_received, nullptr);
+
+    srpc.on_remote_call_received((void *)1, 0, 0, nullptr, 0);
+    EXPECT_EQ(supla_esp_devconn_is_registered(), 1);
+
+  }
+
+  void TearDown() override {
+    supla_esp_devconn_release();
+    upTime = 1100;
+    downTime = 1200;
+    memset(&supla_esp_cfg, 0, sizeof(supla_esp_cfg));
+    memset(&supla_esp_state, 0, sizeof(SuplaEspState));
+    supla_esp_gpio_init_time = 0;
+    cleanupTimers();
+
+    gpioInitCb = nullptr;
+  }
+};
+
+
+TEST_F(RollerShutterMotorProblem, MotorProblemMoveDown) {
+
+  // Set how long [ms] "is_in_move" method will return true
+  upTime = 0;
+  downTime = 0;
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({50, 0, 0, 0, 0, 0, 0, 0})))
+    .Times(2)
+    .WillRepeatedly(Return(0));
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({53, 0, 0, 0, 0, 0, 0, 0})))
+    .WillRepeatedly(Return(0));
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({100, 0, 0, 0x04, 0, 0, 0, 0})))
+    .WillOnce(Return(0));
+
+  supla_esp_cfg.Time1[0] = 0;
+  supla_esp_cfg.Time2[0] = 0;
+  supla_esp_cfg.AutoCalCloseTime[0] = 1000;
+  supla_esp_cfg.AutoCalOpenTime[0] = 1000;
+  supla_esp_state.rs_position[0] = 100 + (50*100);
+  supla_esp_gpio_init();
+
+  supla_roller_shutter_cfg_t *rsCfg = supla_esp_gpio_get_rs__cfg(1);
+  ASSERT_NE(rsCfg, nullptr);
+
+  // +2000 ms
+  for (int i = 0; i < 200; i++) {
+    curTime += 10000; // +10ms
+    executeTimers();
+  }
+
+  // nothing should change
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, 100 + (50*100));
+  EXPECT_EQ(*rsCfg->full_opening_time, 0);
+  EXPECT_EQ(*rsCfg->full_closing_time, 0);
+  EXPECT_EQ(supla_esp_cfg.Time1[0], 0);
+  EXPECT_EQ(supla_esp_cfg.Time2[0], 0);
+  EXPECT_EQ(supla_esp_cfg.AutoCalOpenTime[0], 1000);
+  EXPECT_EQ(supla_esp_cfg.AutoCalCloseTime[0], 1000);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  TSD_SuplaChannelNewValue reqValue = {};
+  reqValue.ChannelNumber = 0;
+  // closing and opening time is coded in 0.1s units on 2x16 bit blocks of
+  // DurationMS
+  // In autocalibration, server sends ct/ot == 0
+  reqValue.DurationMS = (0) | (0 << 16);
+  reqValue.value[0] = 1; // move down
+
+  // simulate request from server
+  supla_esp_channel_set_value(&reqValue);
+
+  for (int i = 0; i < 800; i++) {
+    curTime += 10000; // +10ms
+    executeTimers();
+  }
+
+  EXPECT_EQ(*rsCfg->position, 10100);
+  EXPECT_EQ(supla_esp_cfg.Time1[0], 0);
+  EXPECT_EQ(supla_esp_cfg.Time2[0], 0);
+  EXPECT_EQ(supla_esp_cfg.AutoCalOpenTime[0], 1000);
+  EXPECT_EQ(supla_esp_cfg.AutoCalCloseTime[0], 1000);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+}
+
+TEST_F(RollerShutterMotorProblem, MotorProblemMoveUp) {
+
+  // Set how long [ms] "is_in_move" method will return true
+  upTime = 0;
+  downTime = 0;
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({50, 0, 0, 0, 0, 0, 0, 0})))
+    .Times(2)
+    .WillRepeatedly(Return(0));
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({47, 0, 0, 0, 0, 0, 0, 0})))
+    .WillRepeatedly(Return(0));
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({0, 0, 0, 0x04, 0, 0, 0, 0})))
+    .WillOnce(Return(0));
+
+  supla_esp_cfg.Time1[0] = 0;
+  supla_esp_cfg.Time2[0] = 0;
+  supla_esp_cfg.AutoCalCloseTime[0] = 1000;
+  supla_esp_cfg.AutoCalOpenTime[0] = 1000;
+  supla_esp_state.rs_position[0] = 100 + (50*100);
+  supla_esp_gpio_init();
+
+  supla_roller_shutter_cfg_t *rsCfg = supla_esp_gpio_get_rs__cfg(1);
+  ASSERT_NE(rsCfg, nullptr);
+
+  // +2000 ms
+  for (int i = 0; i < 200; i++) {
+    curTime += 10000; // +10ms
+    executeTimers();
+  }
+
+  // nothing should change
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, 100 + (50*100));
+  EXPECT_EQ(*rsCfg->full_opening_time, 0);
+  EXPECT_EQ(*rsCfg->full_closing_time, 0);
+  EXPECT_EQ(supla_esp_cfg.Time1[0], 0);
+  EXPECT_EQ(supla_esp_cfg.Time2[0], 0);
+  EXPECT_EQ(supla_esp_cfg.AutoCalOpenTime[0], 1000);
+  EXPECT_EQ(supla_esp_cfg.AutoCalCloseTime[0], 1000);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  TSD_SuplaChannelNewValue reqValue = {};
+  reqValue.ChannelNumber = 0;
+  // closing and opening time is coded in 0.1s units on 2x16 bit blocks of
+  // DurationMS
+  // In autocalibration, server sends ct/ot == 0
+  reqValue.DurationMS = (0) | (0 << 16);
+  reqValue.value[0] = 2; // move up
+
+  // simulate request from server
+  supla_esp_channel_set_value(&reqValue);
+
+  for (int i = 0; i < 800; i++) {
+    curTime += 10000; // +10ms
+    executeTimers();
+  }
+
+  EXPECT_EQ(*rsCfg->position, 100);
+  EXPECT_EQ(supla_esp_cfg.Time1[0], 0);
+  EXPECT_EQ(supla_esp_cfg.Time2[0], 0);
+  EXPECT_EQ(supla_esp_cfg.AutoCalOpenTime[0], 1000);
+  EXPECT_EQ(supla_esp_cfg.AutoCalCloseTime[0], 1000);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+}
+
+TEST_F(RollerShutterMotorProblem, MotorProblemMoveUpCloseToFullyOpen) {
+
+  // Set how long [ms] "is_in_move" method will return true
+  upTime = 0;
+  downTime = 0;
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({5, 0, 0, 0, 0, 0, 0, 0})))
+    .Times(2)
+    .WillRepeatedly(Return(0));
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({2, 0, 0, 0, 0, 0, 0, 0})))
+    .WillOnce(Return(0));
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({0, 0, 0, 0, 0, 0, 0, 0})))
+    .WillOnce(Return(0));
+
+  supla_esp_cfg.Time1[0] = 0;
+  supla_esp_cfg.Time2[0] = 0;
+  supla_esp_cfg.AutoCalCloseTime[0] = 1000;
+  supla_esp_cfg.AutoCalOpenTime[0] = 1000;
+  supla_esp_state.rs_position[0] = 100 + (5*100);
+  supla_esp_gpio_init();
+
+  supla_roller_shutter_cfg_t *rsCfg = supla_esp_gpio_get_rs__cfg(1);
+  ASSERT_NE(rsCfg, nullptr);
+
+  // +2000 ms
+  for (int i = 0; i < 200; i++) {
+    curTime += 10000; // +10ms
+    executeTimers();
+  }
+
+  // nothing should change
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, 100 + (5*100));
+  EXPECT_EQ(*rsCfg->full_opening_time, 0);
+  EXPECT_EQ(*rsCfg->full_closing_time, 0);
+  EXPECT_EQ(supla_esp_cfg.Time1[0], 0);
+  EXPECT_EQ(supla_esp_cfg.Time2[0], 0);
+  EXPECT_EQ(supla_esp_cfg.AutoCalOpenTime[0], 1000);
+  EXPECT_EQ(supla_esp_cfg.AutoCalCloseTime[0], 1000);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  TSD_SuplaChannelNewValue reqValue = {};
+  reqValue.ChannelNumber = 0;
+  // closing and opening time is coded in 0.1s units on 2x16 bit blocks of
+  // DurationMS
+  // In autocalibration, server sends ct/ot == 0
+  reqValue.DurationMS = (0) | (0 << 16);
+  reqValue.value[0] = 2; // move up
+
+  // simulate request from server
+  supla_esp_channel_set_value(&reqValue);
+
+  for (int i = 0; i < 800; i++) {
+    curTime += 10000; // +10ms
+    executeTimers();
+  }
+
+  EXPECT_EQ(*rsCfg->position, 100);
+  EXPECT_EQ(supla_esp_cfg.Time1[0], 0);
+  EXPECT_EQ(supla_esp_cfg.Time2[0], 0);
+  EXPECT_EQ(supla_esp_cfg.AutoCalOpenTime[0], 1000);
+  EXPECT_EQ(supla_esp_cfg.AutoCalCloseTime[0], 1000);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+}
+
+TEST_F(RollerShutterMotorProblem, MotorProblemMoveDownCloseToFullyClosed) {
+
+  // Set how long [ms] "is_in_move" method will return true
+  upTime = 0;
+  downTime = 0;
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({95, 0, 0, 0, 0, 0, 0, 0})))
+    .Times(2)
+    .WillRepeatedly(Return(0));
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({98, 0, 0, 0, 0, 0, 0, 0})))
+    .WillOnce(Return(0));
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({100, 0, 0, 0, 0, 0, 0, 0})))
+    .WillOnce(Return(0));
+
+  supla_esp_cfg.Time1[0] = 0;
+  supla_esp_cfg.Time2[0] = 0;
+  supla_esp_cfg.AutoCalCloseTime[0] = 1000;
+  supla_esp_cfg.AutoCalOpenTime[0] = 1000;
+  supla_esp_state.rs_position[0] = 100 + (95*100);
+  supla_esp_gpio_init();
+
+  supla_roller_shutter_cfg_t *rsCfg = supla_esp_gpio_get_rs__cfg(1);
+  ASSERT_NE(rsCfg, nullptr);
+
+  // +2000 ms
+  for (int i = 0; i < 200; i++) {
+    curTime += 10000; // +10ms
+    executeTimers();
+  }
+
+  // nothing should change
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, 100 + (95*100));
+  EXPECT_EQ(*rsCfg->full_opening_time, 0);
+  EXPECT_EQ(*rsCfg->full_closing_time, 0);
+  EXPECT_EQ(supla_esp_cfg.Time1[0], 0);
+  EXPECT_EQ(supla_esp_cfg.Time2[0], 0);
+  EXPECT_EQ(supla_esp_cfg.AutoCalOpenTime[0], 1000);
+  EXPECT_EQ(supla_esp_cfg.AutoCalCloseTime[0], 1000);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  TSD_SuplaChannelNewValue reqValue = {};
+  reqValue.ChannelNumber = 0;
+  // closing and opening time is coded in 0.1s units on 2x16 bit blocks of
+  // DurationMS
+  // In autocalibration, server sends ct/ot == 0
+  reqValue.DurationMS = (0) | (0 << 16);
+  reqValue.value[0] = 1; // move down
+
+  // simulate request from server
+  supla_esp_channel_set_value(&reqValue);
+
+  for (int i = 0; i < 800; i++) {
+    curTime += 10000; // +10ms
+    executeTimers();
+  }
+
+  EXPECT_EQ(*rsCfg->position, 10100);
+  EXPECT_EQ(supla_esp_cfg.Time1[0], 0);
+  EXPECT_EQ(supla_esp_cfg.Time2[0], 0);
+  EXPECT_EQ(supla_esp_cfg.AutoCalOpenTime[0], 1000);
+  EXPECT_EQ(supla_esp_cfg.AutoCalCloseTime[0], 1000);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+}
+
+TEST_F(RollerShutterMotorProblem, MotorProblemByTask) {
+
+  // Set how long [ms] "is_in_move" method will return true
+  upTime = 0;
+  downTime = 0;
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({50, 0, 0, 0, 0, 0, 0, 0})))
+    .Times(2)
+    .WillRepeatedly(Return(0));
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({52, 0, 0, 0, 0, 0, 0, 0})))
+    .WillOnce(Return(0));
+
+  EXPECT_CALL(srpc, 
+      valueChanged(_, 0, ElementsAreArray({90, 0, 0, 0x04, 0, 0, 0, 0})))
+    .WillOnce(Return(0));
+
+  supla_esp_cfg.Time1[0] = 0;
+  supla_esp_cfg.Time2[0] = 0;
+  supla_esp_cfg.AutoCalCloseTime[0] = 1000;
+  supla_esp_cfg.AutoCalOpenTime[0] = 1000;
+  supla_esp_state.rs_position[0] = 100 + (50*100);
+  supla_esp_gpio_init();
+
+  supla_roller_shutter_cfg_t *rsCfg = supla_esp_gpio_get_rs__cfg(1);
+  ASSERT_NE(rsCfg, nullptr);
+
+  // +2000 ms
+  for (int i = 0; i < 200; i++) {
+    curTime += 10000; // +10ms
+    executeTimers();
+  }
+
+  // nothing should change
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, 100 + (50*100));
+  EXPECT_EQ(*rsCfg->full_opening_time, 0);
+  EXPECT_EQ(*rsCfg->full_closing_time, 0);
+  EXPECT_EQ(supla_esp_cfg.Time1[0], 0);
+  EXPECT_EQ(supla_esp_cfg.Time2[0], 0);
+  EXPECT_EQ(supla_esp_cfg.AutoCalOpenTime[0], 1000);
+  EXPECT_EQ(supla_esp_cfg.AutoCalCloseTime[0], 1000);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  TSD_SuplaChannelNewValue reqValue = {};
+  reqValue.ChannelNumber = 0;
+  // closing and opening time is coded in 0.1s units on 2x16 bit blocks of
+  // DurationMS
+  // In autocalibration, server sends ct/ot == 0
+  reqValue.DurationMS = (0) | (0 << 16);
+  reqValue.value[0] = 100; // postion 90
+
+  // simulate request from server
+  supla_esp_channel_set_value(&reqValue);
+
+  for (int i = 0; i < 800; i++) {
+    curTime += 10000; // +10ms
+    executeTimers();
+  }
+
+  EXPECT_EQ(*rsCfg->position, 100 + (90*100));
+  EXPECT_EQ(supla_esp_cfg.Time1[0], 0);
+  EXPECT_EQ(supla_esp_cfg.Time2[0], 0);
+  EXPECT_EQ(supla_esp_cfg.AutoCalOpenTime[0], 1000);
+  EXPECT_EQ(supla_esp_cfg.AutoCalCloseTime[0], 1000);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+}
+

--- a/test/src/roller_shutter_tests.cpp
+++ b/test/src/roller_shutter_tests.cpp
@@ -1935,8 +1935,6 @@ char custom_srpc_getdata(void *_srpc, TsrpcReceivedData *rd, unsigned _supla_int
   return 1;
 }
 
-
-
 TEST_F(RollerShutterTestsF, NotCalibratedWithTargetPositionFromServer) {
   SrpcMock srpc;
   UptimeStub uptime;
@@ -1951,15 +1949,16 @@ TEST_F(RollerShutterTestsF, NotCalibratedWithTargetPositionFromServer) {
 
   EXPECT_CALL(srpc, srpc_getdata(_, _, _)).WillOnce(DoAll(Invoke(custom_srpc_getdata), Return(1)));
   EXPECT_CALL(srpc, srpc_rd_free(_));
+  EXPECT_CALL(srpc, srpc_free(_));
+  EXPECT_CALL(srpc, srpc_dcs_async_set_activity_timeout(_, _));
 
   supla_esp_devconn_init();
   supla_esp_srpc_init();
   ASSERT_NE(srpc.on_remote_call_received, nullptr);
 
   srpc.on_remote_call_received((void *)1, 0, 0, nullptr, 0);
-
   supla_esp_gpio_init();
-
+  EXPECT_EQ(supla_esp_devconn_is_registered(), 1);
 
   supla_roller_shutter_cfg_t *rsCfg = supla_esp_gpio_get_rs__cfg(1);
   ASSERT_NE(rsCfg, nullptr);

--- a/test/src/roller_shutter_tests.cpp
+++ b/test/src/roller_shutter_tests.cpp
@@ -69,6 +69,7 @@ public:
   }
 
   void TearDown() override {
+    cleanupTimers();
     memset(&supla_esp_cfg, 0, sizeof(supla_esp_cfg));
     memset(&supla_esp_state, 0, sizeof(SuplaEspState));
     supla_esp_gpio_init_time = 0;

--- a/test/src/roller_shutter_tests.cpp
+++ b/test/src/roller_shutter_tests.cpp
@@ -19,6 +19,8 @@
 #include <eagle_soc_stub.h>
 #include <gtest/gtest.h>
 #include <time_mock.h>
+#include <srpc_mock.h>
+#include <uptime_stub.h>
 
 extern "C" {
 #include "board_stub.h"
@@ -83,6 +85,9 @@ using ::testing::InSequence;
 using ::testing::Return;
 using ::testing::ReturnPointee;
 using ::testing::SaveArg;
+using ::testing::DoAll;
+using ::testing::SetArgPointee;
+using ::testing::Invoke;
 
 TEST(RollerShutterTests, RsGetValueWithNullCfg) {
   EXPECT_EQ(supla_esp_gpio_rs_get_value(nullptr), RS_RELAY_OFF);
@@ -1922,11 +1927,39 @@ TEST_F(RollerShutterTestsF, NotCalibratedWithRelayUpFromServer) {
   EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
 }
 
+TSD_SuplaRegisterDeviceResult regResult;
+
+char custom_srpc_getdata(void *_srpc, TsrpcReceivedData *rd, unsigned _supla_int_t rr_id) {
+  rd->call_type = SUPLA_SD_CALL_REGISTER_DEVICE_RESULT;
+  rd->data.sd_register_device_result = &regResult;
+  return 1;
+}
+
+
+
 TEST_F(RollerShutterTestsF, NotCalibratedWithTargetPositionFromServer) {
+  SrpcMock srpc;
+  UptimeStub uptime;
   int curTime = 10000; // start at +10 ms
   EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
 
+  EXPECT_CALL(srpc, srpc_params_init(_));
+  EXPECT_CALL(srpc, srpc_init(_)).WillOnce(Return((void *)1));
+  EXPECT_CALL(srpc, srpc_set_proto_version(_, 15));
+
+  regResult.result_code = SUPLA_RESULTCODE_TRUE;
+
+  EXPECT_CALL(srpc, srpc_getdata(_, _, _)).WillOnce(DoAll(Invoke(custom_srpc_getdata), Return(1)));
+  EXPECT_CALL(srpc, srpc_rd_free(_));
+
+  supla_esp_devconn_init();
+  supla_esp_srpc_init();
+  ASSERT_NE(srpc.on_remote_call_received, nullptr);
+
+  srpc.on_remote_call_received((void *)1, 0, 0, nullptr, 0);
+
   supla_esp_gpio_init();
+
 
   supla_roller_shutter_cfg_t *rsCfg = supla_esp_gpio_get_rs__cfg(1);
   ASSERT_NE(rsCfg, nullptr);

--- a/test/src/roller_shutter_tests.cpp
+++ b/test/src/roller_shutter_tests.cpp
@@ -2028,5 +2028,7 @@ TEST_F(RollerShutterTestsF, NotCalibratedWithTargetPositionFromServer) {
   EXPECT_EQ(*rsCfg->full_closing_time, 0);
   EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
   EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  supla_esp_devconn_release();
 }
 


### PR DESCRIPTION
For devices with autocalibtration supported and enabled, there is some error detection and reporting added:
 - motor problem - indicates problems where device expects RS motor to be in move, but it isn't
 - calibration failed - when autocalibration couldn't be completed properly (either too short or too long open/close time)
 - calibration lost - reported in some situations where device expects RS motor to be already stop (at 0 and 100% positions), however it is still in move

Additionally improved RS position handling for RS motors which adds small <1s delay at start of movement.