### PR TITLE
Roller shutter: fixed autocal time calculation

### DIFF
--- a/src/user/supla_esp_gpio.c
+++ b/src/user/supla_esp_gpio.c
@@ -699,21 +699,26 @@ void GPIO_ICACHE_FLASH supla_esp_gpio_rs_timer_cb(void *timer_arg) {
     supla_esp_gpio_rs_check_if_autocal_is_needed(rs_cfg);
 	supla_esp_gpio_rs_task_processing(rs_cfg, isRsInMove);
 
-	if ( rs_cfg->last_time-rs_cfg->last_comm_time >= 500000 ) { // 500 ms.
+	if ( t - rs_cfg->last_comm_time >= 500000 ) { // 500 ms.
 
     if (rs_cfg->last_position != *rs_cfg->position ||
-        rs_cfg->flags != rs_cfg->last_flags) {
+        rs_cfg->last_flags != rs_cfg->flags) {
 
-	  rs_cfg->last_position = *rs_cfg->position;
+      supla_log(LOG_DEBUG, 
+          "New RS value: pos %d (last %d), flags %4x (last %4x)", 
+          *rs_cfg->position, rs_cfg->last_position, 
+          rs_cfg->flags, rs_cfg->last_flags);
+
+      rs_cfg->last_position = *rs_cfg->position;
       rs_cfg->last_flags = rs_cfg->flags;
 
       char value[SUPLA_CHANNELVALUE_SIZE] = {};
       sint8 pos = supla_esp_gpio_rs_get_current_position(rs_cfg);
       TRollerShutterValue *rsValue = (TRollerShutterValue*)value;
+
       rsValue->position = pos;
       rsValue->flags = rs_cfg->flags;
-      supla_log(LOG_DEBUG, "New RS value: pos %d, flags %4x", pos, rs_cfg->flags);
-	  supla_esp_channel_value__changed(rs_cfg->up->channel, value);
+      supla_esp_channel_value__changed(rs_cfg->up->channel, value);
 
 #ifdef BOARD_ON_ROLLERSHUTTER_POSITION_CHANGED
       supla_esp_board_on_rollershutter_position_changed(
@@ -730,8 +735,8 @@ void GPIO_ICACHE_FLASH supla_esp_gpio_rs_timer_cb(void *timer_arg) {
 		//supla_log(LOG_DEBUG, "UT: %i, DT: %i, FOT: %i, FCT: %i, pos: %i", rs_cfg->up_time, rs_cfg->down_time, *rs_cfg->full_opening_time, *rs_cfg->full_closing_time, *rs_cfg->position);
 		rs_cfg->last_comm_time = t;
 	}
-
-	rs_cfg->last_time = t;
+  unsigned int missingTime = (t - rs_cfg->last_time) % 1000; 
+  rs_cfg->last_time = t - missingTime;
 }
 
 void GPIO_ICACHE_FLASH

--- a/test/src/roller_shutter_auto_cal_tests.cpp
+++ b/test/src/roller_shutter_auto_cal_tests.cpp
@@ -615,20 +615,12 @@ TEST_F(RollerShutterAutoCalWithSrpc, RsAutoCalibrated_SetNewPosition) {
     .Times(2)
     .WillRepeatedly(Return(0));
 
-  EXPECT_CALL(srpc, 
-      valueChanged(_, 0, ElementsAreArray({3, 0, 0, 0, 0, 0, 0, 0})))
-    .WillOnce(Return(0));
-
   EXPECT_CALL(srpc,
       valueChanged(_, 0, ElementsAreArray({20, 0, 0, 0, 0, 0, 0, 0})))
     .WillOnce(Return(0));
 
   EXPECT_CALL(srpc,
-      valueChanged(_, 0, ElementsAreArray({26, 0, 0, 0, 0, 0, 0, 0})))
-    .WillOnce(Return(0));
-
-  EXPECT_CALL(srpc,
-      valueChanged(_, 0, ElementsAreArray({77, 0, 0, 0, 0, 0, 0, 0})))
+      valueChanged(_, 0, ElementsAreArray({68, 0, 0, 0, 0, 0, 0, 0})))
     .WillOnce(Return(0));
 
   EXPECT_CALL(srpc,
@@ -814,15 +806,15 @@ TEST_F(RollerShutterAutoCalWithSrpc,
     .WillOnce(Return(0));
 
 
-  // after calibration we set position 80 (intermediate step 6)
+  // after calibration we set position 80 (intermediate step 4)
   char expectedValue5[8] = {};
-  expectedValue5[0] = static_cast<char>(0x06);
+  expectedValue5[0] = static_cast<char>(0x04);
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue5)))
     .WillOnce(Return(0));
 
-  // after calibration we set position 80 (intermediate step 53)
+  // after calibration we set position 80 (intermediate step 50)
   char expectedValue6[8] = {};
-  expectedValue6[0] = static_cast<char>(53);
+  expectedValue6[0] = static_cast<char>(50);
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue6)))
     .WillOnce(Return(0));
 
@@ -2678,12 +2670,12 @@ TEST_F(RollerShutterAutoCalWithSrpc, RsAutoCalibrated_CalibrationLost) {
     .WillRepeatedly(Return(0));
 
   char expectedValue2[8] = {};
-  expectedValue2[0] = static_cast<char>(3);
+  expectedValue2[0] = static_cast<char>(49);
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue2)))
     .WillOnce(Return(0));
 
   char expectedValue3[8] = {};
-  expectedValue3[0] = static_cast<char>(54);
+  expectedValue3[0] = static_cast<char>(99);
   EXPECT_CALL(srpc, valueChanged(_, 0, ElementsAreArray(expectedValue3)))
     .WillOnce(Return(0));
 
@@ -2929,11 +2921,7 @@ TEST_F(RollerShutterAutoCalWithSrpc, RsAutoCalibrated_CalibrationLostMoveDown) {
     .WillRepeatedly(Return(0));
 
   EXPECT_CALL(srpc, 
-      valueChanged(_, 0, ElementsAreArray({4, 0, 0, 0, 0, 0, 0, 0})))
-    .WillRepeatedly(Return(0));
-
-  EXPECT_CALL(srpc, 
-      valueChanged(_, 0, ElementsAreArray({55, 0, 0, 0, 0, 0, 0, 0})))
+      valueChanged(_, 0, ElementsAreArray({50, 0, 0, 0, 0, 0, 0, 0})))
     .WillRepeatedly(Return(0));
 
   EXPECT_CALL(srpc, 

--- a/test/src/roller_shutter_motor_problem_tests.cpp
+++ b/test/src/roller_shutter_motor_problem_tests.cpp
@@ -294,10 +294,6 @@ TEST_F(RollerShutterMotorProblem, MotorProblemMoveUpCloseToFullyOpen) {
     .WillRepeatedly(Return(0));
 
   EXPECT_CALL(srpc, 
-      valueChanged(_, 0, ElementsAreArray({1, 0, 0, 0, 0, 0, 0, 0})))
-    .WillOnce(Return(0));
-
-  EXPECT_CALL(srpc, 
       valueChanged(_, 0, ElementsAreArray({0, 0, 0, 0, 0, 0, 0, 0})))
     .WillOnce(Return(0));
 
@@ -367,10 +363,6 @@ TEST_F(RollerShutterMotorProblem, MotorProblemMoveDownCloseToFullyClosed) {
     .WillRepeatedly(Return(0));
 
   EXPECT_CALL(srpc, 
-      valueChanged(_, 0, ElementsAreArray({99, 0, 0, 0, 0, 0, 0, 0})))
-    .WillOnce(Return(0));
-
-  EXPECT_CALL(srpc, 
       valueChanged(_, 0, ElementsAreArray({100, 0, 0, 0, 0, 0, 0, 0})))
     .WillOnce(Return(0));
 
@@ -438,11 +430,6 @@ TEST_F(RollerShutterMotorProblem, MotorProblemByTask) {
       valueChanged(_, 0, ElementsAreArray({50, 0, 0, 0, 0, 0, 0, 0})))
     .Times(2)
     .WillRepeatedly(Return(0));
-
-  EXPECT_CALL(srpc, 
-      valueChanged(_, 0, ElementsAreArray({53, 0, 0, 
-          RS_VALUE_FLAG_MOTOR_PROBLEM, 0, 0, 0, 0})))
-    .WillOnce(Return(0));
 
   EXPECT_CALL(srpc, valueChanged(_, 0,
         ElementsAreArray({90, 0, 0,
@@ -520,12 +507,6 @@ TEST_F(RollerShutterMotorProblem, MotorProblemWithLongStartupTime) {
       valueChanged(_, 0, ElementsAreArray({50, 0, 0, 0, 0, 0, 0, 0})))
     .Times(2)
     .WillRepeatedly(Return(0));
-
-  EXPECT_CALL(srpc, valueChanged(_, 0,
-        ElementsAreArray({53, 0, 0,
-          RS_VALUE_FLAG_MOTOR_PROBLEM, 0,
-          0, 0, 0})))
-    .WillOnce(Return(0));
 
   EXPECT_CALL(srpc, valueChanged(_, 0,
         ElementsAreArray({90, 0, 0,

--- a/test/src/roller_shutter_tests.cpp
+++ b/test/src/roller_shutter_tests.cpp
@@ -322,7 +322,7 @@ TEST_F(RollerShutterTestsF, MoveDownNotCalibrated) {
   EXPECT_EQ(rsCfg->last_time, 602300000);
   EXPECT_EQ(rsCfg->last_comm_time, 602300000);
   EXPECT_EQ(rsCfg->up_time, 0);
-  EXPECT_EQ(rsCfg->down_time, 600300);
+  EXPECT_EQ(rsCfg->down_time, 0);
   EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
   EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
   EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
@@ -471,7 +471,7 @@ TEST_F(RollerShutterTestsF, MoveUpNotCalibrated) {
 
   EXPECT_EQ(rsCfg->last_time, 602300000);
   EXPECT_EQ(rsCfg->last_comm_time, 602300000);
-  EXPECT_EQ(rsCfg->up_time, 600300);
+  EXPECT_EQ(rsCfg->up_time, 0);
   EXPECT_EQ(rsCfg->down_time, 0);
   EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
   EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));

--- a/test/src/roller_shutter_tests.cpp
+++ b/test/src/roller_shutter_tests.cpp
@@ -2031,3 +2031,138 @@ TEST_F(RollerShutterTestsF, NotCalibratedWithTargetPositionFromServer) {
   supla_esp_devconn_release();
 }
 
+
+TEST_F(RollerShutterTestsF, Task0And100WithTimeMarginCheck) {
+  uint32_t curTime = 100;
+  EXPECT_CALL(time, system_get_time()).WillRepeatedly(ReturnPointee(&curTime));
+
+  supla_esp_gpio_init();
+
+  supla_roller_shutter_cfg_t *rsCfg = supla_esp_gpio_get_rs__cfg(1);
+  ASSERT_NE(rsCfg, nullptr);
+
+  os_timer_func_t *rsTimerCb = lastTimerCb;
+
+  *rsCfg->full_opening_time = 10000; // 10 s
+  *rsCfg->full_closing_time = 10000;
+  *rsCfg->position = 100; // actual position: (x - 100)/100 = 0%
+
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, 100);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // +2000 ms
+  for (int i = 0; i < 200; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  // nothing should change
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, 100);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // Move RS down.
+  EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
+  supla_esp_gpio_rs_add_task(0, 100);
+  EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
+
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, 100);
+  // add task doesn't change relay state. At least one callback has to be called
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  rsTimerCb(rsCfg);
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_TRUE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // +10 s 
+  for (int i = 0; i < 1000; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_LE(rsCfg->down_time, 50);
+  EXPECT_EQ(*rsCfg->position, (100 + (100 * 100)));
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_TRUE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // +400 ms 
+  for (int i = 0; i < 40; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_LE(rsCfg->down_time, 500);
+  EXPECT_EQ(*rsCfg->position, (100 + (100 * 100)));
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_TRUE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // +300 ms 
+  for (int i = 0; i < 30; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, (100 + (100 * 100)));
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+ 
+  // +1300 ms 
+  for (int i = 0; i < 130; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+ 
+  // Move RS up.
+  EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
+  supla_esp_gpio_rs_add_task(0, 0);
+  EXPECT_EQ(rsCfg->delayed_trigger.value, 0);
+
+  // +10.1 s 
+  for (int i = 0; i < 1010; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  EXPECT_LE(rsCfg->up_time, 110);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, (100 + (0 * 100)));
+  EXPECT_TRUE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // +400 ms 
+  for (int i = 0; i < 30; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  EXPECT_LE(rsCfg->up_time, 500);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, (100 + (0 * 100)));
+  EXPECT_TRUE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+
+  // +300 ms 
+  for (int i = 0; i < 30; i++) {
+    curTime += 10000; // +10ms
+    rsTimerCb(rsCfg); // rs timer cb is called every 10 ms
+  }
+
+  EXPECT_EQ(rsCfg->up_time, 0);
+  EXPECT_EQ(rsCfg->down_time, 0);
+  EXPECT_EQ(*rsCfg->position, (100 + (0 * 100)));
+  EXPECT_FALSE(eagleStub.getGpioValue(UP_GPIO));
+  EXPECT_FALSE(eagleStub.getGpioValue(DOWN_GPIO));
+ 
+}


### PR DESCRIPTION
up/down time is accumulated in ms resolution and with 10 ms timer, which could result in up to +-10% error in autocalibration procedure.
