### PR TITLE
Change Wi-Fi scan method to "all channels", so device will connect to best AP available.

### DIFF
--- a/src/user/supla_esp.h
+++ b/src/user/supla_esp.h
@@ -22,7 +22,7 @@
 #include "board/supla_esp_board.h"
 #include "espmissingincludes.h"
 
-#define SUPLA_ESP_SOFTVER "2.8.50"
+#define SUPLA_ESP_SOFTVER "2.8.51"
 
 #define STATE_UNKNOWN 0
 #define STATE_DISCONNECTED 1

--- a/src/user/supla_esp_wifi.c
+++ b/src/user/supla_esp_wifi.c
@@ -104,6 +104,7 @@ supla_esp_wifi_station_connect(_wifi_void_status status_cb) {
   stationConf.ssid[31] = 0;
   stationConf.password[63] = 0;
   stationConf.threshold.rssi = -127;
+  stationConf.all_channel_scan = true;
 
   wifi_station_set_config(&stationConf);
   wifi_station_set_auto_connect(1);

--- a/test/doubles/user_interface.h
+++ b/test/doubles/user_interface.h
@@ -249,6 +249,7 @@ struct station_config {
     uint8 bssid[6];
     wifi_fast_scan_threshold_t threshold;
     bool open_and_wep_mode_disable; // Can connect to open/wep router by default.
+    bool all_channel_scan;
 };
 
 bool wifi_station_get_config(struct station_config *config);


### PR DESCRIPTION
Version increment 2.8.51