### PR TITLE
Facade Blinds: fix invalid tilt value after "missing configuration"

### DIFF
--- a/src/user/supla_esp.h
+++ b/src/user/supla_esp.h
@@ -22,7 +22,7 @@
 #include "board/supla_esp_board.h"
 #include "espmissingincludes.h"
 
-#define SUPLA_ESP_SOFTVER "2.8.61"
+#define SUPLA_ESP_SOFTVER "2.8.62"
 
 #define STATE_UNKNOWN 0
 #define STATE_DISCONNECTED 1

--- a/src/user/supla_esp_gpio.c
+++ b/src/user/supla_esp_gpio.c
@@ -397,9 +397,13 @@ supla_esp_gpio_on_input_inactive(supla_input_cfg_t *input_cfg) {
         if (supla_esp_gpio_rs_get_value(rs_cfg) == direction
             || (supla_esp_gpio_rs_get_value(rs_cfg) == RS_RELAY_OFF
             && rs_cfg->delayed_trigger.value == direction)) {
-          supla_esp_gpio_rs_set_relay(rs_cfg, RS_RELAY_OFF, 1, 1);
+          if (supla_esp_gpio_is_fb(rs_cfg)) {
+            supla_esp_gpio_rs_set_relay(rs_cfg, RS_RELAY_OFF, 1, 0);
+          } else {
+            supla_esp_gpio_rs_set_relay(rs_cfg, RS_RELAY_OFF, 1, 1);
+          }
         }
-      } else { // monostable
+      } else {  // monostable
         if (supla_esp_gpio_rs_get_value(rs_cfg) != RS_RELAY_OFF) {
           supla_esp_gpio_rs_set_relay(rs_cfg, RS_RELAY_OFF, 1, 1);
         } else {

--- a/src/user/supla_esp_rs_fb.c
+++ b/src/user/supla_esp_rs_fb.c
@@ -345,6 +345,11 @@ void GPIO_ICACHE_FLASH supla_esp_gpio_rs_move_position(
   }
 
   int last_pos = *rs_cfg->position;
+
+  if (supla_esp_gpio_rs_is_tilt_supported(rs_cfg) &&
+      (*rs_cfg->tilt < 100 || *rs_cfg->tilt > 10100)) {
+    *rs_cfg->tilt = 100;
+  }
   int last_tilt = *rs_cfg->tilt;
 
   unsigned int full_time = full_time_ms * 1000;


### PR DESCRIPTION
state